### PR TITLE
feat: 한국관광공사_기초지자체 중심 관광지 정보, 지역기반 중심 관광지 정보 목록 조회 기능 구현

### DIFF
--- a/src/main/kotlin/thatline/localup/common/property/TourApiProperty.kt
+++ b/src/main/kotlin/thatline/localup/common/property/TourApiProperty.kt
@@ -10,6 +10,7 @@ class TourApiProperty(
     val mobileOS: String,
     val mobileApp: String,
     val tarRlteTarService: TarRlteTarService,
+    val locgoHubTarService: LocgoHubTarService,
     val tatsCnctrRateService: TatsCnctrRateService,
     val dataLabService: DataLabService,
 ) {
@@ -19,6 +20,22 @@ class TourApiProperty(
      * @see <a href="https://www.data.go.kr/data/15128560/openapi.do">공공데이터포털 API 문서</a>
      */
     data class TarRlteTarService(
+        val firstPath: String,
+        val serviceKey: String,
+        val areaBasedList: AreaBasedList,
+    ) {
+        data class AreaBasedList(
+            val secondPath: String,
+            val responseType: String,
+        )
+    }
+
+    /**
+     * 한국관광공사_기초지자체 중심 관광지 정보
+     *
+     * @see <a href="https://www.data.go.kr/data/15128559/openapi.do">공공데이터포털 API 문서</a>
+     */
+    data class LocgoHubTarService(
         val firstPath: String,
         val serviceKey: String,
         val areaBasedList: AreaBasedList,

--- a/src/main/kotlin/thatline/localup/tourapi/controller/TourApiController.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/controller/TourApiController.kt
@@ -6,14 +6,8 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import thatline.localup.tourapi.exception.ExternalTourApiException
-import thatline.localup.tourapi.request.AreaBasedListRequest
-import thatline.localup.tourapi.request.LocgoRegnVisitrDDListRequest
-import thatline.localup.tourapi.request.MetcoRegnVisitrDDListRequest
-import thatline.localup.tourapi.request.TatsCnctrRatedListRequest
-import thatline.localup.tourapi.response.AreaBasedListResponse
-import thatline.localup.tourapi.response.LocgoRegnVisitrDDListResponse
-import thatline.localup.tourapi.response.MetcoRegnVisitrDDListResponse
-import thatline.localup.tourapi.response.TatsCnctrRatedListResponse
+import thatline.localup.tourapi.request.*
+import thatline.localup.tourapi.response.*
 import thatline.localup.tourapi.restclient.TourApiRestClient
 
 @RestController
@@ -34,6 +28,29 @@ class TourApiController(
         request: AreaBasedListRequest,
     ): ResponseEntity<AreaBasedListResponse> {
         val response = tourApiRestClient.areaBasedList(
+            pageNo = request.pageNo,
+            numOfRows = request.numOfRows,
+            baseYm = request.baseYm,
+            areaCd = request.areaCd,
+            signguCd = request.signguCd,
+        )
+
+        return ResponseEntity.ok(response)
+    }
+
+    /**
+     * 한국관광공사_기초지자체 중심 관광지 정보: 지역기반 중심 관광지 정보 목록 조회
+     *
+     * @param request [AreaBasedListRequest2]
+     * @return [ResponseEntity]<[AreaBasedListResponse2]>
+     *
+     * @see <a href="https://www.data.go.kr/data/15128559/openapi.do">공공데이터포털 API 문서</a>
+     */
+    @GetMapping("/areaBasedList2")
+    fun areaBasedList2(
+        request: AreaBasedListRequest2,
+    ): ResponseEntity<AreaBasedListResponse2> {
+        val response = tourApiRestClient.areaBasedList2(
             pageNo = request.pageNo,
             numOfRows = request.numOfRows,
             baseYm = request.baseYm,

--- a/src/main/kotlin/thatline/localup/tourapi/request/AreaBasedListRequest2.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/request/AreaBasedListRequest2.kt
@@ -1,0 +1,20 @@
+package thatline.localup.tourapi.request
+
+/**
+ * 한국관광공사_기초지자체 중심 관광지 정보: 지역기반 중심 관광지 정보 목록 조회
+ *
+ * @property pageNo 페이지 번호
+ * @property numOfRows 한 페이지 결과 수
+ * @property baseYm 기준 날짜 조회
+ * @property areaCd 중심지 지역 코드
+ * @property signguCd 중심지 시군구 코드
+ *
+ * @see <a href="https://www.data.go.kr/data/15128559/openapi.do">공공데이터포털 API 문서</a>
+ */
+data class AreaBasedListRequest2(
+    val pageNo: Long,
+    val numOfRows: Long,
+    val baseYm: String,
+    val areaCd: String,
+    val signguCd: String,
+)

--- a/src/main/kotlin/thatline/localup/tourapi/response/AreaBasedListResponse2.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/response/AreaBasedListResponse2.kt
@@ -1,0 +1,89 @@
+package thatline.localup.tourapi.response
+
+/**
+ * 한국관광공사_기초지자체 중심 관광지 정보: 지역기반 중심 관광지 정보 목록 조회
+ *
+ * @property response 응답
+ *
+ * @see <a href="https://www.data.go.kr/data/15128559/openapi.do">공공데이터포털 API 문서</a>
+ */
+data class AreaBasedListResponse2(
+    val response: Response,
+) {
+    /**
+     * 응답
+     *
+     * @property header 헤더
+     * @property body 본문
+     */
+    data class Response(
+        val header: Header,
+        val body: Body,
+    )
+
+    /**
+     * 헤더
+     *
+     * @property resultCode 결과 코드
+     * @property resultMsg 결과 메시지
+     */
+    data class Header(
+        val resultCode: String,
+        val resultMsg: String,
+    )
+
+    /**
+     * 본문
+     *
+     * @property items 목록
+     * @property numOfRows 한 페이지 결과 수
+     * @property pageNo 페이지 번호
+     * @property totalCount 전체 결과 수
+     */
+    data class Body(
+        val items: Items,
+        val numOfRows: Long,
+        val pageNo: Long,
+        val totalCount: Long,
+    )
+
+    /**
+     * 목록
+     *
+     * @property item 항목들
+     */
+    data class Items(
+        val item: List<Item>,
+    )
+
+    /**
+     * 항목
+     *
+     * @property baseYm 기준 연월
+     * @property mapX X좌표 값
+     * @property mapY Y좌표 값
+     * @property areaCd 지역 코드
+     * @property areaNm 지역명
+     * @property signguCd 시군구 코드
+     * @property signguNm 시군구명
+     * @property hubTatsCd 중심지 관광지 코드
+     * @property hubTatsNm 중심지 관광지명
+     * @property hubCtgryLclsNm 중심지 카테고리 대분류명
+     * @property hubCtgryMclsNm 중심지 카테고리 중분류명
+     * @property hubRank 중심지 순위
+     */
+    data class Item(
+        val baseYm: String,
+        val mapX: String,
+        val mapY: String,
+        val areaCd: String,
+        val areaNm: String,
+        val signguCd: String,
+        val signguNm: String,
+        val hubTatsCd: String,
+        val hubTatsNm: String,
+        val hubCtgryLclsNm: String,
+        val hubCtgryMclsNm: String,
+        val hubRank: String,
+    )
+}

--- a/src/main/kotlin/thatline/localup/tourapi/restclient/TourApiRestClient.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/restclient/TourApiRestClient.kt
@@ -6,10 +6,7 @@ import org.springframework.web.client.RestClientException
 import org.springframework.web.util.UriComponentsBuilder
 import thatline.localup.common.property.TourApiProperty
 import thatline.localup.tourapi.exception.ExternalTourApiException
-import thatline.localup.tourapi.response.AreaBasedListResponse
-import thatline.localup.tourapi.response.LocgoRegnVisitrDDListResponse
-import thatline.localup.tourapi.response.MetcoRegnVisitrDDListResponse
-import thatline.localup.tourapi.response.TatsCnctrRatedListResponse
+import thatline.localup.tourapi.response.*
 import java.net.URI
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -57,6 +54,48 @@ class TourApiRestClient(
             .toUri()
 
         val response = retrieveTourApi(uri, AreaBasedListResponse::class.java)
+
+        return response
+    }
+
+    /**
+     * 한국관광공사_기초지자체 중심 관광지 정보: 지역기반 중심 관광지 정보 목록 조회
+     *
+     * @param pageNo 페이지 번호
+     * @param numOfRows 한 페이지 결과 수
+     * @param baseYm 기준 날짜 조회
+     * @param areaCd 중심지 지역 코드
+     * @param signguCd 중심지 시군구 코드
+     * @return [AreaBasedListResponse2]
+     *
+     * @see <a href="https://www.data.go.kr/data/15128559/openapi.do">공공데이터포털 API 문서</a>
+     */
+    fun areaBasedList2(
+        pageNo: Long,
+        numOfRows: Long,
+        baseYm: String,
+        areaCd: String,
+        signguCd: String,
+    ): AreaBasedListResponse2 {
+        val fromUri = URI.create(
+            "${tourApiProperty.baseUrl}${tourApiProperty.locgoHubTarService.firstPath}${tourApiProperty.locgoHubTarService.areaBasedList.secondPath}"
+        )
+
+        val uri = UriComponentsBuilder
+            .fromUri(fromUri)
+            .queryParam("serviceKey", tourApiProperty.locgoHubTarService.serviceKey)
+            .queryParam("pageNo", pageNo)
+            .queryParam("numOfRows", numOfRows)
+            .queryParam("MobileOS", tourApiProperty.mobileOS)
+            .queryParam("MobileApp", tourApiProperty.mobileApp)
+            .queryParam("baseYm", baseYm)
+            .queryParam("areaCd", areaCd)
+            .queryParam("signguCd", signguCd)
+            .queryParam("_type", tourApiProperty.locgoHubTarService.areaBasedList.responseType)
+            .build(true)
+            .toUri()
+
+        val response = retrieveTourApi(uri, AreaBasedListResponse2::class.java)
 
         return response
     }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -29,6 +29,11 @@ tour-api:
   tar-rlte-tar-service:
     service-key: ${TAR_RLTE_TAR_SERVICE_KEY}
 
+  # 한국관광공사_기초지자체 중심 관광지 정보
+  # link: https://www.data.go.kr/data/15128559/openapi.do
+  locgo-hub-tar-service:
+    service-key: ${LOCGO_HUB_TAR_SERVICE_KEY}
+
   # 한국관광공사_관광지 집중률 방문자 추이 예측 정보
   tats-cnctr-rate-service:
     service-key: ${TATS_CNCTR_RATE_SERVICE_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,8 +12,17 @@ tour-api:
   # link: https://www.data.go.kr/data/15128560/openapi.do
   tar-rlte-tar-service:
     first-path: /B551011/TarRlteTarService1
+    # 지역기반 관광지별 연관 관광지 정보 목록 조회
     area-based-list:
-      # 지역기반 관광지별 연관 관광지 정보 목록 조회
+      second-path: /areaBasedList1
+      response-type: JSON
+
+  # 한국관광공사_기초지자체 중심 관광지 정보
+  # link: https://www.data.go.kr/data/15128559/openapi.do
+  locgo-hub-tar-service:
+    first-path: /B551011/LocgoHubTarService1
+    # 지역기반 중심 관광지 정보 목록 조회
+    area-based-list:
       second-path: /areaBasedList1
       response-type: JSON
 


### PR DESCRIPTION
# feat: 한국관광공사_기초지자체 중심 관광지 정보, 지역기반 중심 관광지 정보 목록 조회 기능 구현

## Note

- Tour API, 한국관광공사_기초지자체 중심 관광지 정보, 지역기반 중심 관광지 정보 목록 조회 API를 활용하기 위해 기능을 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 한국관광공사 기초지자체 중심 관광지 정보(Open API) 연동을 위한 새로운 관광지 목록 조회 엔드포인트가 추가되었습니다.
    - 지역 기반 관광지 목록 조회를 위한 새로운 요청 및 응답 형식이 도입되었습니다.

- **설정**
    - 관련 API 연동을 위한 서비스 키 및 경로 정보가 환경설정 파일에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->