### PR TITLE
feat: 사용자 인가 기능 추가

### DIFF
--- a/src/main/kotlin/thatline/localup/admin/controller/AdminController.kt
+++ b/src/main/kotlin/thatline/localup/admin/controller/AdminController.kt
@@ -1,0 +1,27 @@
+package thatline.localup.admin.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import thatline.localup.common.annotation.RequireMaster
+import thatline.localup.common.annotation.RequireUser
+
+@RestController
+@RequestMapping("/api/admin")
+class AdminController {
+
+    // TODO: 테스트 코드 삭제
+    @GetMapping("/master")
+    @RequireMaster
+    fun master(): ResponseEntity<Unit> {
+        return ResponseEntity.ok().build()
+    }
+
+    // TODO: 테스트 코드 삭제
+    @GetMapping("/user")
+    @RequireUser
+    fun user(): ResponseEntity<Unit> {
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/thatline/localup/auth/dto/UserDetails.kt
+++ b/src/main/kotlin/thatline/localup/auth/dto/UserDetails.kt
@@ -1,0 +1,8 @@
+package thatline.localup.auth.dto
+
+import thatline.localup.common.constant.Role
+
+data class UserDetails(
+    val id: String,
+    val role: Role,
+)

--- a/src/main/kotlin/thatline/localup/common/annotation/RequireMaster.kt
+++ b/src/main/kotlin/thatline/localup/common/annotation/RequireMaster.kt
@@ -1,0 +1,8 @@
+package thatline.localup.common.annotation
+
+import org.springframework.security.access.prepost.PreAuthorize
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@PreAuthorize("hasRole('MASTER')")
+annotation class RequireMaster

--- a/src/main/kotlin/thatline/localup/common/annotation/RequireUser.kt
+++ b/src/main/kotlin/thatline/localup/common/annotation/RequireUser.kt
@@ -4,5 +4,5 @@ import org.springframework.security.access.prepost.PreAuthorize
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-@PreAuthorize("hasAnyRole('MASTER', 'MANAGER', 'USER')")
+@PreAuthorize("hasAnyRole('MASTER', 'USER')")
 annotation class RequireUser

--- a/src/main/kotlin/thatline/localup/common/annotation/RequireUser.kt
+++ b/src/main/kotlin/thatline/localup/common/annotation/RequireUser.kt
@@ -1,0 +1,8 @@
+package thatline.localup.common.annotation
+
+import org.springframework.security.access.prepost.PreAuthorize
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@PreAuthorize("hasAnyRole('MASTER', 'MANAGER', 'USER')")
+annotation class RequireUser

--- a/src/main/kotlin/thatline/localup/common/configuration/SecurityConfiguration.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/SecurityConfiguration.kt
@@ -3,15 +3,17 @@ package thatline.localup.common.configuration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.web.cors.CorsConfiguration
-import thatline.localup.common.filter.AuthenticationFilter
 import thatline.localup.common.constant.Environment
+import thatline.localup.common.filter.AuthenticationFilter
 
 @Configuration
+@EnableMethodSecurity(prePostEnabled = true)
 class SecurityConfiguration(
     private val authenticationFilter: AuthenticationFilter,
 ) {

--- a/src/main/kotlin/thatline/localup/common/constant/Role.kt
+++ b/src/main/kotlin/thatline/localup/common/constant/Role.kt
@@ -1,0 +1,8 @@
+package thatline.localup.common.constant
+
+enum class Role {
+    MASTER,
+    USER;
+
+    fun toAuthority(): String = "ROLE_$name"
+}

--- a/src/main/kotlin/thatline/localup/common/filter/AuthenticationFilter.kt
+++ b/src/main/kotlin/thatline/localup/common/filter/AuthenticationFilter.kt
@@ -3,6 +3,7 @@ package thatline.localup.common.filter
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
@@ -25,10 +26,12 @@ class AuthenticationFilter(
         val accessToken = cookies?.firstOrNull { it.name == tokenProperty.accessToken.name }?.value
 
         if (!accessToken.isNullOrBlank()) {
-            val userId = authService.findUserIdByAccessToken(accessToken)
+            val userDetails = authService.findUserDetailsByAccessToken(accessToken)
 
-            if (userId != null) {
-                SecurityContextHolder.getContext().authentication = AuthenticationToken(userId)
+            if (userDetails != null) {
+                val authorities = listOf(SimpleGrantedAuthority(userDetails.role.toAuthority()))
+
+                SecurityContextHolder.getContext().authentication = AuthenticationToken(userDetails.id, authorities)
             }
         }
 

--- a/src/main/kotlin/thatline/localup/user/entity/mongodb/UserMongoDbEntity.kt
+++ b/src/main/kotlin/thatline/localup/user/entity/mongodb/UserMongoDbEntity.kt
@@ -3,6 +3,7 @@ package thatline.localup.user.entity.mongodb
 import org.bson.types.ObjectId
 import org.springframework.data.mongodb.core.mapping.Document
 import thatline.localup.common.entity.mongodb.BaseMongoDbEntity
+import thatline.localup.common.constant.Role
 import java.time.LocalDateTime
 
 @Document(collection = "user")
@@ -16,6 +17,8 @@ class UserMongoDbEntity(
     val email: String,
 
     val password: String,
+
+    val role: Role,
 
     val zipCode: String?,
 

--- a/src/main/kotlin/thatline/localup/user/service/UserService.kt
+++ b/src/main/kotlin/thatline/localup/user/service/UserService.kt
@@ -1,7 +1,6 @@
 package thatline.localup.user.service
 
 import org.springframework.stereotype.Service
-import thatline.localup.common.constant.Role
 import thatline.localup.user.entity.mongodb.UserMongoDbEntity
 import thatline.localup.user.exception.UserNotFoundException
 import thatline.localup.user.repository.mongodb.UserMongoDbRepository

--- a/src/main/kotlin/thatline/localup/user/service/UserService.kt
+++ b/src/main/kotlin/thatline/localup/user/service/UserService.kt
@@ -1,6 +1,7 @@
 package thatline.localup.user.service
 
 import org.springframework.stereotype.Service
+import thatline.localup.common.constant.Role
 import thatline.localup.user.entity.mongodb.UserMongoDbEntity
 import thatline.localup.user.exception.UserNotFoundException
 import thatline.localup.user.repository.mongodb.UserMongoDbRepository
@@ -28,6 +29,7 @@ class UserService(
 
             email = user.email,
             password = user.password,
+            role = user.role,
 
             zipCode = zipCode,
             address = address,
@@ -38,4 +40,28 @@ class UserService(
 
         userRepository.save(updatedUser)
     }
+
+    // TODO: 추후
+//    fun updateUserRole(id: String, role: Role) {
+//        val user = userRepository.findById(id)
+//            .orElseThrow { UserNotFoundException() }
+//
+//        val updatedUser = UserMongoDbEntity(
+//            id = user.id,
+//            createdDate = user.createdDate,
+//            lastModifiedDate = LocalDateTime.now(),
+//
+//            email = user.email,
+//            password = user.password,
+//            role = role,
+//
+//            zipCode = user.zipCode,
+//            address = user.address,
+//            addressDetail = user.addressDetail,
+//            latitude = user.latitude,
+//            longitude = user.longitude
+//        )
+//
+//        userRepository.save(updatedUser)
+//    }
 }

--- a/src/test/kotlin/thatline/localup/auth/RoleTest.kt
+++ b/src/test/kotlin/thatline/localup/auth/RoleTest.kt
@@ -1,0 +1,42 @@
+package thatline.localup.auth
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import kotlin.test.Test
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class RoleTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `ROLE_MASTER가 master 접근`() {
+        mockMvc.perform(get("/api/admin/master").with(user("username").roles("MASTER")))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `ROLE_USER가 master 접근`() {
+        mockMvc.perform(get("/api/admin/master").with(user("username").roles("USER")))
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `ROLE_MASTER가 user 접근`() {
+        mockMvc.perform(get("/api/admin/user").with(user("username").roles("MASTER")))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `ROLE_USER가 user 접근`() {
+        mockMvc.perform(get("/api/admin/user").with(user("username").roles("USER")))
+            .andExpect(status().isOk)
+    }
+}


### PR DESCRIPTION
# feat: 사용자 인가 기능 추가

## Note

- 추후 관리자가 LLM 모델을 선택할 수 있도록 인가 기능을 추가했습니다.
- 현재 인가는 앱에 종속적입니다. 추후 서비스가 커지면 분리하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 역할(Role) 기반 접근 제어가 도입되었습니다.
  * MASTER/USER 권한을 확인하는 어노테이션(@RequireMaster, @RequireUser)이 추가되었습니다.
  * 관리용 REST 엔드포인트(/api/admin/master, /api/admin/user)가 추가되었습니다.

* **버그 수정**
  * 인증 필터가 사용자 역할 정보를 포함하여 인증 토큰을 처리하도록 개선되었습니다.

* **테스트**
  * 역할별 접근 권한을 검증하는 통합 테스트가 추가되었습니다.

* **기타**
  * 사용자 엔티티에 역할 필드가 추가되었습니다.
  * 역할(Role) 관련 열거형(enum) 및 유틸리티 메서드가 도입되었습니다.
  * 메서드 수준의 시큐리티 설정이 활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->