### PR TITLE
feat: 사용자가 업체를 등록할 수 있도록 구현 (user와 business 분리)

### DIFF
--- a/src/main/kotlin/thatline/localup/auth/service/AuthService.kt
+++ b/src/main/kotlin/thatline/localup/auth/service/AuthService.kt
@@ -50,11 +50,7 @@ class AuthService(
             email = email,
             password = hashedPassword,
             role = Role.USER,
-            zipCode = null,
-            address = null,
-            addressDetail = null,
-            latitude = null,
-            longitude = null,
+            businessId = null,
         )
 
         userRepository.save(newUser)

--- a/src/main/kotlin/thatline/localup/user/controller/UserController.kt
+++ b/src/main/kotlin/thatline/localup/user/controller/UserController.kt
@@ -6,8 +6,11 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import thatline.localup.common.response.BaseResponse
+import thatline.localup.user.exception.BusinessAlreadyRegisteredException
+import thatline.localup.user.exception.BusinessNotRegisteredException
 import thatline.localup.user.exception.UserNotFoundException
-import thatline.localup.user.request.UpdateAddressRequest
+import thatline.localup.user.request.RegisterBusinessRequest
+import thatline.localup.user.request.UpdateBusinessRequest
 import thatline.localup.user.service.UserService
 
 @RestController
@@ -15,18 +18,41 @@ import thatline.localup.user.service.UserService
 class UserController(
     private val userService: UserService,
 ) {
-    @PutMapping("/address")
-    fun updateAddress(
-        @AuthenticationPrincipal id: String,
-        @RequestBody @Valid request: UpdateAddressRequest,
+    @PostMapping("/business")
+    fun registerBusiness(
+        @AuthenticationPrincipal userId: String,
+        @RequestBody @Valid request: RegisterBusinessRequest,
     ): ResponseEntity<BaseResponse<Unit>> {
-        userService.updateAddress(
-            id = id,
-            zipCode = request.zipCode,
-            address = request.address,
-            addressDetail = request.addressDetail,
-            latitude = request.latitude,
-            longitude = request.longitude
+        userService.registerBusiness(
+            userId = userId,
+            businessName = request.businessName,
+            businessZipCode = request.businessZipCode,
+            businessAddress = request.businessAddress,
+            businessAddressDetail = request.businessAddressDetail,
+            businessLatitude = request.businessLatitude,
+            businessLongitude = request.businessLongitude,
+            businessType = request.businessType,
+            businessItem = request.businessItem,
+        )
+
+        return ResponseEntity.ok(BaseResponse.success())
+    }
+
+    @PatchMapping("/business")
+    fun updateBusiness(
+        @AuthenticationPrincipal userId: String,
+        @RequestBody @Valid request: UpdateBusinessRequest,
+    ): ResponseEntity<BaseResponse<Unit>> {
+        userService.updateBusiness(
+            userId = userId,
+            businessName = request.businessName,
+            businessZipCode = request.businessZipCode,
+            businessAddress = request.businessAddress,
+            businessAddressDetail = request.businessAddressDetail,
+            businessLatitude = request.businessLatitude,
+            businessLongitude = request.businessLongitude,
+            businessType = request.businessType,
+            businessItem = request.businessItem,
         )
 
         return ResponseEntity.ok(BaseResponse.success())
@@ -34,6 +60,28 @@ class UserController(
 
     @ExceptionHandler(UserNotFoundException::class)
     fun handleUserNotFoundException(exception: UserNotFoundException): ResponseEntity<BaseResponse<Unit>> {
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(
+                BaseResponse.failure(
+                    message = exception.message
+                )
+            )
+    }
+
+    @ExceptionHandler(BusinessAlreadyRegisteredException::class)
+    fun handleBusinessAlreadyRegisteredException(exception: BusinessAlreadyRegisteredException): ResponseEntity<BaseResponse<Unit>> {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(
+                BaseResponse.failure(
+                    message = exception.message
+                )
+            )
+    }
+
+    @ExceptionHandler(BusinessNotRegisteredException::class)
+    fun handleBusinessNotRegisteredException(exception: BusinessNotRegisteredException): ResponseEntity<BaseResponse<Unit>> {
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)
             .body(

--- a/src/main/kotlin/thatline/localup/user/entity/mongodb/BusinessMongoDbEntity.kt
+++ b/src/main/kotlin/thatline/localup/user/entity/mongodb/BusinessMongoDbEntity.kt
@@ -1,0 +1,39 @@
+package thatline.localup.user.entity.mongodb
+
+import org.bson.types.ObjectId
+import org.springframework.data.mongodb.core.mapping.Document
+import thatline.localup.common.entity.mongodb.BaseMongoDbEntity
+import java.time.LocalDateTime
+
+@Document(collection = "business")
+class BusinessMongoDbEntity(
+    id: String = ObjectId().toHexString(),
+
+    createdDate: LocalDateTime = LocalDateTime.now(),
+
+    lastModifiedDate: LocalDateTime = createdDate,
+
+    // 상호명
+    val name: String,
+
+    // 사업장(단체) 소재지, 우편번호
+    val zipCode: String,
+
+    // 사업장(단체) 소재지, 주소
+    val address: String,
+
+    // 사업장(단체) 소재지, 주소 상세
+    val addressDetail: String?,
+
+    // 사업장(단체) 소재지, 위도
+    val latitude: Double,
+
+    // 사업장(단체) 소재지, 경도
+    val longitude: Double,
+
+    // 업종, 주업태
+    val type: String,
+
+    // 업종, 주종목
+    val item: String,
+) : BaseMongoDbEntity(id, createdDate, lastModifiedDate)

--- a/src/main/kotlin/thatline/localup/user/entity/mongodb/UserMongoDbEntity.kt
+++ b/src/main/kotlin/thatline/localup/user/entity/mongodb/UserMongoDbEntity.kt
@@ -1,9 +1,10 @@
 package thatline.localup.user.entity.mongodb
 
 import org.bson.types.ObjectId
+import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
-import thatline.localup.common.entity.mongodb.BaseMongoDbEntity
 import thatline.localup.common.constant.Role
+import thatline.localup.common.entity.mongodb.BaseMongoDbEntity
 import java.time.LocalDateTime
 
 @Document(collection = "user")
@@ -20,14 +21,7 @@ class UserMongoDbEntity(
 
     val role: Role,
 
-    val zipCode: String?,
-
-    val address: String?,
-
-    val addressDetail: String?,
-
-    val latitude: Double?,
-
-    val longitude: Double?,
+    @Indexed(unique = true, sparse = true)
+    val businessId: String?,
 
     ) : BaseMongoDbEntity(id, createdDate, lastModifiedDate)

--- a/src/main/kotlin/thatline/localup/user/exception/BusinessAlreadyRegisteredException.kt
+++ b/src/main/kotlin/thatline/localup/user/exception/BusinessAlreadyRegisteredException.kt
@@ -1,0 +1,7 @@
+package thatline.localup.user.exception
+
+import thatline.localup.common.exception.BaseException
+
+class BusinessAlreadyRegisteredException(
+    cause: Throwable? = null,
+) : BaseException("BUSINESS_ALREADY_REGISTERED", cause)

--- a/src/main/kotlin/thatline/localup/user/exception/BusinessNotRegisteredException.kt
+++ b/src/main/kotlin/thatline/localup/user/exception/BusinessNotRegisteredException.kt
@@ -1,0 +1,7 @@
+package thatline.localup.user.exception
+
+import thatline.localup.common.exception.BaseException
+
+class BusinessNotRegisteredException(
+    cause: Throwable? = null,
+) : BaseException("BUSINESS_NOT_REGISTERED", cause)

--- a/src/main/kotlin/thatline/localup/user/repository/mongodb/BusinessMongoDbRepository.kt
+++ b/src/main/kotlin/thatline/localup/user/repository/mongodb/BusinessMongoDbRepository.kt
@@ -1,0 +1,6 @@
+package thatline.localup.user.repository.mongodb
+
+import org.springframework.data.mongodb.repository.MongoRepository
+import thatline.localup.user.entity.mongodb.BusinessMongoDbEntity
+
+interface BusinessMongoDbRepository : MongoRepository<BusinessMongoDbEntity, String>

--- a/src/main/kotlin/thatline/localup/user/request/RegisterBusinessRequest.kt
+++ b/src/main/kotlin/thatline/localup/user/request/RegisterBusinessRequest.kt
@@ -1,0 +1,27 @@
+package thatline.localup.user.request
+
+import jakarta.validation.constraints.DecimalMax
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.NotBlank
+import thatline.localup.common.annotation.NotBlankIfNotNull
+
+data class RegisterBusinessRequest(
+    @field:NotBlank
+    val businessName: String,
+    @field:NotBlank
+    val businessZipCode: String,
+    @field:NotBlank
+    val businessAddress: String,
+    @field:NotBlankIfNotNull
+    val businessAddressDetail: String?,
+    @field:DecimalMin(value = "-90.0")
+    @field:DecimalMax(value = "90.0")
+    val businessLatitude: Double,
+    @field:DecimalMin(value = "-180.0")
+    @field:DecimalMax(value = "180.0")
+    val businessLongitude: Double,
+    @field:NotBlank
+    val businessType: String,
+    @field:NotBlank
+    val businessItem: String,
+)

--- a/src/main/kotlin/thatline/localup/user/request/UpdateBusinessRequest.kt
+++ b/src/main/kotlin/thatline/localup/user/request/UpdateBusinessRequest.kt
@@ -5,21 +5,23 @@ import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.NotBlank
 import thatline.localup.common.annotation.NotBlankIfNotNull
 
-data class UpdateAddressRequest(
+data class UpdateBusinessRequest(
     @field:NotBlank
-    val zipCode: String,
-
+    val businessName: String,
     @field:NotBlank
-    val address: String,
-
+    val businessZipCode: String,
+    @field:NotBlank
+    val businessAddress: String,
     @field:NotBlankIfNotNull
-    val addressDetail: String?,
-
+    val businessAddressDetail: String?,
     @field:DecimalMin(value = "-90.0")
     @field:DecimalMax(value = "90.0")
-    val latitude: Double,
-
+    val businessLatitude: Double,
     @field:DecimalMin(value = "-180.0")
     @field:DecimalMax(value = "180.0")
-    val longitude: Double,
+    val businessLongitude: Double,
+    @field:NotBlank
+    val businessType: String,
+    @field:NotBlank
+    val businessItem: String,
 )


### PR DESCRIPTION
# feat: 사용자가 업체를 등록할 수 있도록 구현 (user와 business 분리)

## Note

- 사용자와 사업 정보를 분리하여 별도의 문서에 저장할 수 있도록 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 사업장 등록/수정 API 추가: POST /api/users/business, PATCH /api/users/business. 이름, 우편번호, 주소, 위도/경도, 업종, 품목에 대한 유효성 검증 적용.
  - 사업장 상태별 오류 응답 개선: 이미 등록된 경우 400, 미등록 상태에서 수정 시 404 반환.
- Refactor
  - 사용자 주소 수정 엔드포인트를 사업장 등록/수정 엔드포인트로 대체하여 기능을 사업장 중심으로 일원화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->