### PR TITLE
refactor: 캐시 관련 객체 이름, 키 생성자 이름 문자열 대신 상수로 관리할 수 있도록 개선

### DIFF
--- a/src/main/kotlin/thatline/localup/common/configuration/CacheConfiguration.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/CacheConfiguration.kt
@@ -12,6 +12,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
+import thatline.localup.common.constant.CacheObjectName
 import thatline.localup.common.util.DateTimeUtil
 import thatline.localup.etcapi.dto.WeatherInformation
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
@@ -19,7 +20,6 @@ import java.time.Duration
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.temporal.ChronoUnit
-
 
 @Configuration
 @EnableCaching
@@ -60,8 +60,8 @@ class CacheConfiguration(
             .entryTtl(Duration.ofHours(3))
 
         val cacheConfigurations = mapOf(
-            "weatherInformation" to weatherInformationCacheConfiguration,
-            "lastMonthlyTouristAttractionRankingInformation" to lastMonthlyTouristAttractionRankingInformationCacheConfiguration,
+            CacheObjectName.LAST_MONTHLY_TOURIST_ATTRACTION_RANKING_INFORMATION to lastMonthlyTouristAttractionRankingInformationCacheConfiguration,
+            CacheObjectName.WEATHER_INFORMATION to weatherInformationCacheConfiguration,
             // 다른 캐시 설정 추가
         )
 

--- a/src/main/kotlin/thatline/localup/common/constant/CacheKeyGeneratorName.kt
+++ b/src/main/kotlin/thatline/localup/common/constant/CacheKeyGeneratorName.kt
@@ -1,0 +1,6 @@
+package thatline.localup.common.constant
+
+object CacheKeyGeneratorName {
+    const val LAST_MONTHLY_TOURIST_ATTRACTION_RANKING = "lastMonthlyTouristAttractionRankingKeyGenerator"
+    const val WEATHER_INFORMATION = "weatherInformationKeyGenerator"
+}

--- a/src/main/kotlin/thatline/localup/common/constant/CacheObjectName.kt
+++ b/src/main/kotlin/thatline/localup/common/constant/CacheObjectName.kt
@@ -1,0 +1,6 @@
+package thatline.localup.common.constant
+
+object CacheObjectName {
+    const val LAST_MONTHLY_TOURIST_ATTRACTION_RANKING_INFORMATION = "lastMonthlyTouristAttractionRankingInformation"
+    const val WEATHER_INFORMATION = "weatherInformation"
+}

--- a/src/main/kotlin/thatline/localup/etcapi/service/WeatherService.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/service/WeatherService.kt
@@ -3,6 +3,8 @@ package thatline.localup.etcapi.service
 import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
+import thatline.localup.common.constant.CacheKeyGeneratorName
+import thatline.localup.common.constant.CacheObjectName
 import thatline.localup.common.constant.TourApi
 import thatline.localup.common.util.DateTimeUtil
 import thatline.localup.etcapi.code.UltraSrtNcstResponseCode
@@ -21,7 +23,11 @@ class WeatherService(
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
 
-    @Cacheable(cacheNames = ["weatherInformation"], keyGenerator = "weatherInformationKeyGenerator", sync = true)
+    @Cacheable(
+        cacheNames = [CacheObjectName.WEATHER_INFORMATION],
+        keyGenerator = CacheKeyGeneratorName.WEATHER_INFORMATION,
+        sync = true
+    )
     fun getThreeDayWeatherSummaries(
         sigunguCode: String,
     ): WeatherInformation {

--- a/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
@@ -2,6 +2,8 @@ package thatline.localup.tourapi.service
 
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
+import thatline.localup.common.constant.CacheKeyGeneratorName
+import thatline.localup.common.constant.CacheObjectName
 import thatline.localup.common.util.DateTimeUtil
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRanking
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
@@ -13,8 +15,8 @@ class TouristAttractionService(
     private val tourApiRestClient: TourApiRestClient,
 ) {
     @Cacheable(
-        cacheNames = ["lastMonthlyTouristAttractionRankingInformation"],
-        keyGenerator = "lastMonthlyTouristAttractionRankingKeyGenerator",
+        cacheNames = [CacheObjectName.LAST_MONTHLY_TOURIST_ATTRACTION_RANKING_INFORMATION],
+        keyGenerator = CacheKeyGeneratorName.LAST_MONTHLY_TOURIST_ATTRACTION_RANKING,
         sync = true
     )
     fun findLastMonthlyTouristAttractionRanking(


### PR DESCRIPTION
# refactor: 캐시 관련 객체 이름, 키 생성자 이름 문자열 대신 상수로 관리할 수 있도록 개선

## Note

- 캐시 관련 객체 이름과 키 생성자 이름을 기존 문자열 하드코딩 방식에서 상수로 분리하여 관리하도록 리팩터링했습니다.
  - 오타/중복 방지
  - 유지보수성 향상
  - 가독성 강화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 캐시 이름과 키 생성기 참조를 문자열에서 상수 기반으로 통일했습니다.
  - 날씨 및 관광지 랭킹 관련 서비스의 캐싱 설정을 상수로 교체했습니다.
  - 초기 캐시 구성 순서를 정리했습니다.

- **Style**
  - 경미한 포맷 정리를 수행했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->