### PR TITLE
feat: 대시보드, 지역 방문자 통계 조회 기능 추가

### DIFF
--- a/src/main/kotlin/thatline/localup/common/constant/CacheKeyGeneratorName.kt
+++ b/src/main/kotlin/thatline/localup/common/constant/CacheKeyGeneratorName.kt
@@ -2,5 +2,6 @@ package thatline.localup.common.constant
 
 object CacheKeyGeneratorName {
     const val LAST_MONTHLY_TOURIST_ATTRACTION_RANKING = "lastMonthlyTouristAttractionRankingKeyGenerator"
+    const val LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS = "lastYearSameWeekVisitorStatistics"
     const val WEATHER_INFORMATION = "weatherInformationKeyGenerator"
 }

--- a/src/main/kotlin/thatline/localup/common/constant/CacheObjectName.kt
+++ b/src/main/kotlin/thatline/localup/common/constant/CacheObjectName.kt
@@ -2,5 +2,6 @@ package thatline.localup.common.constant
 
 object CacheObjectName {
     const val LAST_MONTHLY_TOURIST_ATTRACTION_RANKING_INFORMATION = "lastMonthlyTouristAttractionRankingInformation"
+    const val LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS_INFORMATION = "lastYearSameWeekVisitorStatisticsInformation"
     const val WEATHER_INFORMATION = "weatherInformation"
 }

--- a/src/main/kotlin/thatline/localup/common/util/DateTimeUtil.kt
+++ b/src/main/kotlin/thatline/localup/common/util/DateTimeUtil.kt
@@ -1,10 +1,37 @@
 package thatline.localup.common.util
 
+import java.time.DayOfWeek
+import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoField
+import java.time.temporal.WeekFields
+import kotlin.math.min
 
 object DateTimeUtil {
     val DATETIME_FORMATTER_yyyyMM: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMM")
     val DATETIME_FORMATTER_yyyyMMdd: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
     val DATETIME_FORMATTER_yyyyMMddHHmm: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmm")
     val DATETIME_FORMATTER_HHmm: DateTimeFormatter = DateTimeFormatter.ofPattern("HHmm")
+
+    // LocalDate 기준, 작년 같은 ISO 주차 범위 반환
+    fun getLastYearSameIsoWeekRange(localDate: LocalDate = LocalDate.now()): Pair<LocalDate, LocalDate> {
+        val isoWeekFields = WeekFields.ISO
+        val currentWeekNumber = localDate.get(isoWeekFields.weekOfWeekBasedYear())
+        val lastYearWeekYear = localDate.get(isoWeekFields.weekBasedYear()) - 1
+        val lastYearMaxWeek = LocalDate.of(lastYearWeekYear, 12, 28)
+            .get(isoWeekFields.weekOfWeekBasedYear())
+        val adjustedWeekNumber = min(currentWeekNumber, lastYearMaxWeek)
+
+        return isoWeekRangeOf(lastYearWeekYear, adjustedWeekNumber)
+    }
+
+    // ISO 주차 범위, 월 ~ 일 반환
+    private fun isoWeekRangeOf(weekBasedYear: Int, week: Int): Pair<LocalDate, LocalDate> {
+        val startLocalDate = LocalDate.of(weekBasedYear, 1, 4)
+            .with(WeekFields.ISO.weekOfWeekBasedYear(), week.toLong())
+            .with(ChronoField.DAY_OF_WEEK, DayOfWeek.MONDAY.value.toLong())
+        val endLocalDate = startLocalDate.plusDays(6)
+
+        return startLocalDate to endLocalDate
+    }
 }

--- a/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
@@ -2,8 +2,10 @@ package thatline.localup.dashboard.dto
 
 import thatline.localup.etcapi.dto.WeatherInformation
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
+import thatline.localup.tourapi.dto.VisitorStatistic
 
 data class DashboardOverview(
     val lastMonthlyTouristAttractionRankingInformation: LastMonthlyTouristAttractionRankingInformation,
+    val lastYearSameWeekVisitorStatistics: List<VisitorStatistic>,
     val weatherInformation: WeatherInformation,
 )

--- a/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
@@ -2,10 +2,10 @@ package thatline.localup.dashboard.dto
 
 import thatline.localup.etcapi.dto.WeatherInformation
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
-import thatline.localup.tourapi.dto.VisitorStatistic
+import thatline.localup.tourapi.dto.LastYearSameWeekVisitorStatisticsInformation
 
 data class DashboardOverview(
     val lastMonthlyTouristAttractionRankingInformation: LastMonthlyTouristAttractionRankingInformation,
-    val lastYearSameWeekVisitorStatistics: List<VisitorStatistic>,
+    val lastYearSameWeekVisitorStatisticsInformation: LastYearSameWeekVisitorStatisticsInformation,
     val weatherInformation: WeatherInformation,
 )

--- a/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
@@ -21,9 +21,10 @@ class DashboardFacade(
                 sigunguCode = foundUserBusinessDto.sigunguCode
             )
 
-        val lastYearSameWeekVisitorStatistics = touristAttractionService.findLastYearSameWeekVisitorStatistics(
-            sigunguCode = foundUserBusinessDto.sigunguCode
-        )
+        val lastYearSameWeekVisitorStatisticsInformation =
+            touristAttractionService.findLastYearSameWeekVisitorStatistics(
+                sigunguCode = foundUserBusinessDto.sigunguCode
+            )
 
         val weatherInformation = weatherService.getThreeDayWeatherSummaries(
             sigunguCode = foundUserBusinessDto.sigunguCode
@@ -31,7 +32,7 @@ class DashboardFacade(
 
         return DashboardOverview(
             lastMonthlyTouristAttractionRankingInformation = lastMonthlyTouristAttractionRankingInformation,
-            lastYearSameWeekVisitorStatistics = lastYearSameWeekVisitorStatistics,
+            lastYearSameWeekVisitorStatisticsInformation = lastYearSameWeekVisitorStatisticsInformation,
             weatherInformation = weatherInformation,
         )
     }

--- a/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
@@ -21,12 +21,17 @@ class DashboardFacade(
                 sigunguCode = foundUserBusinessDto.sigunguCode
             )
 
+        val lastYearSameWeekVisitorStatistics = touristAttractionService.findLastYearSameWeekVisitorStatistics(
+            sigunguCode = foundUserBusinessDto.sigunguCode
+        )
+
         val weatherInformation = weatherService.getThreeDayWeatherSummaries(
             sigunguCode = foundUserBusinessDto.sigunguCode
         )
 
         return DashboardOverview(
             lastMonthlyTouristAttractionRankingInformation = lastMonthlyTouristAttractionRankingInformation,
+            lastYearSameWeekVisitorStatistics = lastYearSameWeekVisitorStatistics,
             weatherInformation = weatherInformation,
         )
     }

--- a/src/main/kotlin/thatline/localup/tourapi/dto/LastYearSameWeekVisitorStatisticsInformation.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/dto/LastYearSameWeekVisitorStatisticsInformation.kt
@@ -1,0 +1,8 @@
+package thatline.localup.tourapi.dto
+
+import java.time.LocalDateTime
+
+data class LastYearSameWeekVisitorStatisticsInformation(
+    val updatedDate: LocalDateTime,
+    val visitorStatistics: List<VisitorStatistic>,
+)

--- a/src/main/kotlin/thatline/localup/tourapi/dto/VisitorStatistic.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/dto/VisitorStatistic.kt
@@ -1,0 +1,10 @@
+package thatline.localup.tourapi.dto
+
+import java.time.LocalDate
+
+data class VisitorStatistic(
+    val date: LocalDate,
+    val localVisitors: Int,
+    val domesticVisitors: Int,
+    val foreignVisitors: Int,
+)

--- a/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
@@ -7,9 +7,11 @@ import thatline.localup.common.constant.CacheObjectName
 import thatline.localup.common.util.DateTimeUtil
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRanking
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
+import thatline.localup.tourapi.dto.LastYearSameWeekVisitorStatisticsInformation
 import thatline.localup.tourapi.dto.VisitorStatistic
 import thatline.localup.tourapi.restclient.TourApiRestClient
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 import kotlin.math.roundToInt
 
@@ -17,7 +19,6 @@ import kotlin.math.roundToInt
 class TouristAttractionService(
     private val tourApiRestClient: TourApiRestClient,
 ) {
-    //
     @Cacheable(
         cacheNames = [CacheObjectName.LAST_MONTHLY_TOURIST_ATTRACTION_RANKING_INFORMATION],
         keyGenerator = CacheKeyGeneratorName.LAST_MONTHLY_TOURIST_ATTRACTION_RANKING,
@@ -61,9 +62,14 @@ class TouristAttractionService(
     }
 
     // TODO-noah: API의 한계로 별도의 배치 작업으로 개선하면 좋을 것 같음
+    @Cacheable(
+        cacheNames = [CacheObjectName.LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS_INFORMATION],
+        keyGenerator = CacheKeyGeneratorName.LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS,
+        sync = true
+    )
     fun findLastYearSameWeekVisitorStatistics(
         sigunguCode: String,
-    ): List<VisitorStatistic> {
+    ): LastYearSameWeekVisitorStatisticsInformation {
         val (startDate, endDate) = DateTimeUtil.getLastYearSameIsoWeekRange()
 
         val startYmd = startDate.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
@@ -105,6 +111,9 @@ class TouristAttractionService(
             }
             .sortedBy { it.date }
 
-        return visitorStatistics
+        return LastYearSameWeekVisitorStatisticsInformation(
+            updatedDate = LocalDateTime.now(),
+            visitorStatistics = visitorStatistics
+        )
     }
 }

--- a/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
@@ -7,13 +7,17 @@ import thatline.localup.common.constant.CacheObjectName
 import thatline.localup.common.util.DateTimeUtil
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRanking
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
+import thatline.localup.tourapi.dto.VisitorStatistic
 import thatline.localup.tourapi.restclient.TourApiRestClient
+import java.time.LocalDate
 import java.time.YearMonth
+import kotlin.math.roundToInt
 
 @Service
 class TouristAttractionService(
     private val tourApiRestClient: TourApiRestClient,
 ) {
+    //
     @Cacheable(
         cacheNames = [CacheObjectName.LAST_MONTHLY_TOURIST_ATTRACTION_RANKING_INFORMATION],
         keyGenerator = CacheKeyGeneratorName.LAST_MONTHLY_TOURIST_ATTRACTION_RANKING,
@@ -54,5 +58,53 @@ class TouristAttractionService(
             updatedDate = yearMonth.atDay(1).atStartOfDay(),
             lastMonthlyTouristAttractionRankingList = lastMonthlyTouristAttractionRankingList
         )
+    }
+
+    // TODO-noah: API의 한계로 별도의 배치 작업으로 개선하면 좋을 것 같음
+    fun findLastYearSameWeekVisitorStatistics(
+        sigunguCode: String,
+    ): List<VisitorStatistic> {
+        val (startDate, endDate) = DateTimeUtil.getLastYearSameIsoWeekRange()
+
+        val startYmd = startDate.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
+        val endYmd = endDate.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
+
+        val response1 = tourApiRestClient.locgoRegnVisitrDDList(
+            pageNo = 1,
+            numOfRows = 1,
+            startYmd = startYmd,
+            endYmd = endYmd,
+        )
+
+        // TODO: 예외 처리 필요
+
+        val response2 = tourApiRestClient.locgoRegnVisitrDDList(
+            pageNo = 1,
+            numOfRows = response1.response.body.totalCount,
+            startYmd = startYmd,
+            endYmd = endYmd,
+        )
+
+        // TODO: 예외 처리 필요
+
+        val items = response2.response.body.items.item
+
+        val visitorStatistics = items
+            .filter { it.signguCode == sigunguCode }
+            .groupBy { it.baseYmd }
+            .map { (date, data) ->
+                // 관광객 구분 코드
+                val visitorCode = data.associateBy { it.touDivCd }
+
+                VisitorStatistic(
+                    date = LocalDate.parse(date, DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd),
+                    localVisitors = visitorCode["1"]?.touNum?.toDouble()?.roundToInt() ?: 0,
+                    domesticVisitors = visitorCode["2"]?.touNum?.toDouble()?.roundToInt() ?: 0,
+                    foreignVisitors = visitorCode["3"]?.touNum?.toDouble()?.roundToInt() ?: 0,
+                )
+            }
+            .sortedBy { it.date }
+
+        return visitorStatistics
     }
 }


### PR DESCRIPTION
# feat: 대시보드, 지역 방문자 통계 조회 기능 추가

## Note

- 대시보드에서 작년, 같은 달, 같은 주 지역 방문자 통계를 조회할 수 있도록 구현했습니다.
- 현지인, 외지인, 외국인 지역 방문자 수를 담고 있습니다.

응답 중 일부

```json
        "lastYearSameWeekVisitorStatisticsInformation": {
            "updatedDate": "2025-08-16T17:55:24.3489979",
            "visitorStatistics": [
                {
                    "date": "2024-08-12",
                    "localVisitors": 11666,
                    "domesticVisitors": 18487,
                    "foreignVisitors": 65
                },
                {
                    "date": "2024-08-13",
                    "localVisitors": 11505,
                    "domesticVisitors": 19320,
                    "foreignVisitors": 79
                },
                {
                    "date": "2024-08-14",
                    "localVisitors": 11732,
                    "domesticVisitors": 22005,
                    "foreignVisitors": 58
                },
                {
                    "date": "2024-08-15",
                    "localVisitors": 9639,
                    "domesticVisitors": 34384,
                    "foreignVisitors": 97
                },
                {
                    "date": "2024-08-16",
                    "localVisitors": 11442,
                    "domesticVisitors": 23433,
                    "foreignVisitors": 54
                },
                {
                    "date": "2024-08-17",
                    "localVisitors": 9555,
                    "domesticVisitors": 33621,
                    "foreignVisitors": 77
                },
                {
                    "date": "2024-08-18",
                    "localVisitors": 9268,
                    "domesticVisitors": 29824,
                    "foreignVisitors": 90
                }
            ]
        },
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 대시보드에 전년도 동일 주(ISO) 방문자 통계가 추가되었습니다. 선택 지역 기준으로 월요일~일요일 일자별 집계가 제공되며, 내방·국내·외국 방문자 수를 각각 확인할 수 있습니다. 최신 갱신 시각이 함께 표시되고, 날짜순으로 정렬되어 대시보드 개요에 포함됩니다.
- 성능
  - 해당 통계가 7일간 캐시되어 재방문 시 로딩 속도가 개선되고 불필요한 외부 호출이 감소합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->