### PR TITLE
feat: dashboard 지역 축제 API 변경 및 적용

### DIFF
--- a/src/main/kotlin/thatline/localup/common/configuration/CacheConfiguration.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/CacheConfiguration.kt
@@ -17,6 +17,7 @@ import thatline.localup.common.util.DateTimeUtil
 import thatline.localup.etcapi.dto.WeatherInformation
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
 import thatline.localup.tourapi.dto.LastYearSameWeekVisitorStatisticsInformation
+import thatline.localup.tourapi.dto.OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation
 import thatline.localup.tourapi.dto.SigunguEventInformation
 import java.time.Duration
 import java.time.LocalDateTime
@@ -73,6 +74,18 @@ class CacheConfiguration(
             )
             .entryTtl(Duration.ofDays(1))
 
+        // 대시보드, 법정동 시군구 기준, 오늘 날짜 ~ 월 마지막 일 축제/공연/행사 정보 캐시 설정
+        val ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformationCacheConfiguration = defaultCacheConfiguration
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    Jackson2JsonRedisSerializer(
+                        objectMapper,
+                        OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation::class.java
+                    )
+                )
+            )
+            .entryTtl(Duration.ofDays(1))
+
         // 대시보드, 날씨 정보 캐시 설정
         val weatherInformationCacheConfiguration = defaultCacheConfiguration
             .serializeValuesWith(
@@ -90,6 +103,7 @@ class CacheConfiguration(
             CacheObjectName.LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS_INFORMATION to lastYearSameWeekVisitorStatisticsInformationCacheConfiguration,
             CacheObjectName.WEATHER_INFORMATION to weatherInformationCacheConfiguration,
             CacheObjectName.SIGUNGU_EVENT_INFORMATION to sigunguEventInformationCacheConfiguration,
+            CacheObjectName.ONGOING_OR_UPCOMING_SIGUNGU_EVENTS_FROM_TODAY_TO_MONTH_END_INFORMATION to ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformationCacheConfiguration,
             // 다른 캐시 설정 추가
         )
 
@@ -132,6 +146,17 @@ class CacheConfiguration(
             val savedDateTime = LocalDateTime.now().format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
 
             "$sigunguCode-$savedDateTime"
+        }
+    }
+
+    @Bean
+    fun ongoingOrUpComingSigunguEventsFromTodayToMonthEndKeyGenerator(): KeyGenerator {
+        return KeyGenerator { _, _, params ->
+            val legalDongSigunguCode = params[0] as String
+
+            val savedDateTime = LocalDateTime.now().format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
+
+            "$legalDongSigunguCode-$savedDateTime"
         }
     }
 

--- a/src/main/kotlin/thatline/localup/common/constant/CacheKeyGeneratorName.kt
+++ b/src/main/kotlin/thatline/localup/common/constant/CacheKeyGeneratorName.kt
@@ -2,8 +2,11 @@ package thatline.localup.common.constant
 
 object CacheKeyGeneratorName {
     const val LAST_MONTHLY_TOURIST_ATTRACTION_RANKING = "lastMonthlyTouristAttractionRankingKeyGenerator"
+
     // TODO-noah: rename
     const val LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS = "lastYearSameWeekVisitorStatistics"
     const val SIGUNGU_EVENT = "sigunguEventKeyGenerator"
+    const val ONGOING_OR_UPCOMING_SIGUNGU_EVENTS_FROM_TODAY_TO_MONTH_END =
+        "ongoingOrUpComingSigunguEventsFromTodayToMonthEndKeyGenerator"
     const val WEATHER_INFORMATION = "weatherInformationKeyGenerator"
 }

--- a/src/main/kotlin/thatline/localup/common/constant/CacheObjectName.kt
+++ b/src/main/kotlin/thatline/localup/common/constant/CacheObjectName.kt
@@ -4,5 +4,7 @@ object CacheObjectName {
     const val LAST_MONTHLY_TOURIST_ATTRACTION_RANKING_INFORMATION = "lastMonthlyTouristAttractionRankingInformation"
     const val LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS_INFORMATION = "lastYearSameWeekVisitorStatisticsInformation"
     const val SIGUNGU_EVENT_INFORMATION = "sigunguEventInformation"
+    const val ONGOING_OR_UPCOMING_SIGUNGU_EVENTS_FROM_TODAY_TO_MONTH_END_INFORMATION =
+        "ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation"
     const val WEATHER_INFORMATION = "weatherInformation"
 }

--- a/src/main/kotlin/thatline/localup/common/property/TourApiProperty.kt
+++ b/src/main/kotlin/thatline/localup/common/property/TourApiProperty.kt
@@ -26,6 +26,7 @@ class TourApiProperty(
         val areaCode2: AreaCode2,
         val ldongCode2: LdongCode2,
         val areaBasedList2: AreaBasedList2,
+        val detailIntro2: DetailIntro2,
     ) {
         data class AreaCode2(
             val secondPath: String,
@@ -38,6 +39,10 @@ class TourApiProperty(
         )
 
         data class AreaBasedList2(
+            val secondPath: String,
+        )
+
+        data class DetailIntro2(
             val secondPath: String,
         )
     }

--- a/src/main/kotlin/thatline/localup/common/property/TourApiProperty.kt
+++ b/src/main/kotlin/thatline/localup/common/property/TourApiProperty.kt
@@ -26,6 +26,7 @@ class TourApiProperty(
         val areaCode2: AreaCode2,
         val ldongCode2: LdongCode2,
         val areaBasedList2: AreaBasedList2,
+        val searchFestival2: SearchFestival2,
         val detailIntro2: DetailIntro2,
     ) {
         data class AreaCode2(
@@ -39,6 +40,10 @@ class TourApiProperty(
         )
 
         data class AreaBasedList2(
+            val secondPath: String,
+        )
+
+        data class SearchFestival2(
             val secondPath: String,
         )
 

--- a/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
@@ -3,11 +3,11 @@ package thatline.localup.dashboard.dto
 import thatline.localup.etcapi.dto.WeatherInformation
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
 import thatline.localup.tourapi.dto.LastYearSameWeekVisitorStatisticsInformation
-import thatline.localup.tourapi.dto.SigunguEventWithDates
+import thatline.localup.tourapi.dto.OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation
 
 data class DashboardOverview(
     val lastMonthlyTouristAttractionRankingInformation: LastMonthlyTouristAttractionRankingInformation,
     val lastYearSameWeekVisitorStatisticsInformation: LastYearSameWeekVisitorStatisticsInformation,
-    val ongoingOrUpComingSigunguEventsFromTodayToMonthEnd: List<SigunguEventWithDates>,
+    val ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation: OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation,
     val weatherInformation: WeatherInformation,
 )

--- a/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
@@ -3,11 +3,11 @@ package thatline.localup.dashboard.dto
 import thatline.localup.etcapi.dto.WeatherInformation
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
 import thatline.localup.tourapi.dto.LastYearSameWeekVisitorStatisticsInformation
-import thatline.localup.tourapi.dto.SigunguEventInformation
+import thatline.localup.tourapi.dto.SigunguEventWithDates
 
 data class DashboardOverview(
     val lastMonthlyTouristAttractionRankingInformation: LastMonthlyTouristAttractionRankingInformation,
     val lastYearSameWeekVisitorStatisticsInformation: LastYearSameWeekVisitorStatisticsInformation,
-    val sigunguEventInformation: SigunguEventInformation,
+    val ongoingOrUpComingSigunguEventsFromTodayToMonthEnd: List<SigunguEventWithDates>,
     val weatherInformation: WeatherInformation,
 )

--- a/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
@@ -27,9 +27,10 @@ class DashboardFacade(
                 sigunguCode = foundUserBusinessDto.sigunguCode
             )
 
-        val sigunguEventInformation = touristAttractionService.findSigunguEvent(
-            legalDongSigunguCode = foundUserBusinessDto.sigunguCode,
-        )
+        val ongoingOrUpComingSigunguEventsFromTodayToMonthEnd =
+            touristAttractionService.findOngoingOrUpComingSigunguEventsFromTodayToMonthEnd(
+                legalDongSigunguCode = foundUserBusinessDto.sigunguCode,
+            )
 
         val weatherInformation = weatherService.getThreeDayWeatherSummaries(
             sigunguCode = foundUserBusinessDto.sigunguCode
@@ -38,7 +39,7 @@ class DashboardFacade(
         return DashboardOverview(
             lastMonthlyTouristAttractionRankingInformation = lastMonthlyTouristAttractionRankingInformation,
             lastYearSameWeekVisitorStatisticsInformation = lastYearSameWeekVisitorStatisticsInformation,
-            sigunguEventInformation = sigunguEventInformation,
+            ongoingOrUpComingSigunguEventsFromTodayToMonthEnd = ongoingOrUpComingSigunguEventsFromTodayToMonthEnd,
             weatherInformation = weatherInformation,
         )
     }

--- a/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
@@ -27,7 +27,7 @@ class DashboardFacade(
                 sigunguCode = foundUserBusinessDto.sigunguCode
             )
 
-        val ongoingOrUpComingSigunguEventsFromTodayToMonthEnd =
+        val ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation =
             touristAttractionService.findOngoingOrUpComingSigunguEventsFromTodayToMonthEnd(
                 legalDongSigunguCode = foundUserBusinessDto.sigunguCode,
             )
@@ -39,7 +39,7 @@ class DashboardFacade(
         return DashboardOverview(
             lastMonthlyTouristAttractionRankingInformation = lastMonthlyTouristAttractionRankingInformation,
             lastYearSameWeekVisitorStatisticsInformation = lastYearSameWeekVisitorStatisticsInformation,
-            ongoingOrUpComingSigunguEventsFromTodayToMonthEnd = ongoingOrUpComingSigunguEventsFromTodayToMonthEnd,
+            ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation = ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation,
             weatherInformation = weatherInformation,
         )
     }

--- a/src/main/kotlin/thatline/localup/tourapi/dto/OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/dto/OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation.kt
@@ -1,0 +1,8 @@
+package thatline.localup.tourapi.dto
+
+import java.time.LocalDateTime
+
+data class OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation(
+    val updatedDate: LocalDateTime,
+    val sigunguEventsWithDates: List<SigunguEventWithDates>,
+)

--- a/src/main/kotlin/thatline/localup/tourapi/dto/SigunguEventWithDates.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/dto/SigunguEventWithDates.kt
@@ -1,0 +1,18 @@
+package thatline.localup.tourapi.dto
+
+import java.time.LocalDate
+
+data class SigunguEventWithDates(
+    val contentTypeId: String,
+    val contentId: String,
+    val title: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val zipCode: String,
+    val address: String,
+    val latitude: Double,
+    val longitude: Double,
+    val telephone: String,
+    val originalImageUrl: String,
+    val thumbnailImageUrl: String,
+)

--- a/src/main/kotlin/thatline/localup/tourapi/response/KorService2DetailIntro215Response.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/response/KorService2DetailIntro215Response.kt
@@ -1,0 +1,147 @@
+package thatline.localup.tourapi.response
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+
+/**
+ * 한국관광공사_국문 관광정보 서비스_GW: 소개 정보 조회
+ *
+ * @property response 응답
+ *
+ * @see <a href="https://www.data.go.kr/data/15101578/openapi.do">공공데이터포털 API 문서</a>
+ */
+data class KorService2DetailIntro215Response(
+    val response: Response,
+) {
+    /**
+     * 응답
+     *
+     * @property header 헤더
+     * @property body 본문
+     */
+    data class Response(
+        val header: Header,
+        val body: Body,
+    )
+
+    /**
+     * 헤더
+     *
+     * @property resultCode 결과 코드
+     * @property resultMsg 결과 메시지
+     */
+    data class Header(
+        val resultCode: String,
+        val resultMsg: String,
+    )
+
+    /**
+     * 본문
+     *
+     * @property items 목록
+     * @property numOfRows 한 페이지 결과 수
+     * @property pageNo 페이지 번호
+     * @property totalCount 전체 결과 수
+     */
+    data class Body(
+        val items: Items,
+        val numOfRows: Long,
+        val pageNo: Long,
+        val totalCount: Long,
+    )
+
+    /**
+     * 목록
+     *
+     * @property item 항목들
+     */
+    @JsonDeserialize(using = KorService2DetailIntro215ResponseItemsJsonDeserializer::class)
+    data class Items(
+        val item: List<Item>,
+    )
+
+    /**
+     * 항목
+     *
+     * @property contentid 콘텐츠 ID
+     * @property contenttypeid 콘텐츠 타입 ID
+     * @property sponsor1 주최자 정보
+     * @property sponsor1tel 주최자 연락처
+     * @property sponsor2 주관사 정보
+     * @property sponsor2tel 주관사 연락처
+     * @property eventenddate 행사 종료일
+     * @property playtime 공연 시간
+     * @property eventplace 행사 장소
+     * @property eventhomepage 행사 홈페이지
+     * @property agelimit 관람 가능 연령
+     * @property bookingplace 예매처
+     * @property placeinfo 행사장 위치 안내
+     * @property subevent 부대 행사
+     * @property program 행사 프로그램
+     * @property eventstartdate 행사 시작일
+     * @property usetimefestival 이용 요금
+     * @property discountinfofestival 할인 정보
+     * @property spendtimefestival 관람 소요 시간
+     * @property festivalgrade 축제 등급
+     * @property progresstype 진행 상태 정보
+     * @property festivaltype 축제 유형명
+     */
+    data class Item(
+        val contentid: String,
+        val contenttypeid: String,
+        val sponsor1: String,
+        val sponsor1tel: String,
+        val sponsor2: String,
+        val sponsor2tel: String,
+        val eventenddate: String,
+        val playtime: String,
+        val eventplace: String,
+        val eventhomepage: String,
+        val agelimit: String,
+        val bookingplace: String,
+        val placeinfo: String,
+        val subevent: String,
+        val program: String,
+        val eventstartdate: String,
+        val usetimefestival: String,
+        val discountinfofestival: String,
+        val spendtimefestival: String,
+        val festivalgrade: String,
+        val progresstype: String,
+        val festivaltype: String,
+    )
+}
+
+private class KorService2DetailIntro215ResponseItemsJsonDeserializer :
+    JsonDeserializer<KorService2DetailIntro215Response.Items>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): KorService2DetailIntro215Response.Items {
+        val jsonNode = p.codec.readTree<JsonNode>(p)
+
+        return when {
+            // 빈 문자열인 경우
+            jsonNode.isTextual && jsonNode.asText().isEmpty() -> {
+                KorService2DetailIntro215Response.Items(emptyList())
+            }
+
+            // 정상
+            jsonNode.isObject && jsonNode.has("item") -> {
+                val itemJsonNode = jsonNode.get("item")
+
+                val items = if (itemJsonNode.isArray) {
+                    p.codec.treeToValue(itemJsonNode, Array<KorService2DetailIntro215Response.Item>::class.java)
+                        .toList()
+                } else {
+                    emptyList()
+                }
+                KorService2DetailIntro215Response.Items(items)
+            }
+
+            else -> {
+                KorService2DetailIntro215Response.Items(emptyList())
+            }
+        }
+    }
+}

--- a/src/main/kotlin/thatline/localup/tourapi/response/KorService2SearchFestival2Response.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/response/KorService2SearchFestival2Response.kt
@@ -1,0 +1,161 @@
+package thatline.localup.tourapi.response
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+
+/**
+ * 한국관광공사_국문 관광정보 서비스_GW: 행사 정보 조회
+ *
+ * @property response 응답
+ *
+ * @see <a href="https://www.data.go.kr/data/15101578/openapi.do">공공데이터포털 API 문서</a>
+ */
+data class KorService2SearchFestival2Response(
+    val response: Response,
+) {
+    /**
+     * 응답
+     *
+     * @property header 헤더
+     * @property body 본문
+     */
+    data class Response(
+        val header: Header,
+        val body: Body,
+    )
+
+    /**
+     * 헤더
+     *
+     * @property resultCode 결과 코드
+     * @property resultMsg 결과 메시지
+     */
+    data class Header(
+        val resultCode: String,
+        val resultMsg: String,
+    )
+
+    /**
+     * 본문
+     *
+     * @property items 목록
+     * @property numOfRows 한 페이지 결과 수
+     * @property pageNo 페이지 번호
+     * @property totalCount 전체 결과 수
+     */
+    data class Body(
+        val items: Items,
+        val numOfRows: Long,
+        val pageNo: Long,
+        val totalCount: Long,
+    )
+
+    /**
+     * 목록
+     *
+     * @property item 항목들
+     */
+    @JsonDeserialize(using = KorService2SearchFestival2ResponseItemsJsonDeserializer::class)
+    data class Items(
+        val item: List<Item>,
+    )
+
+    /**
+     * 항목
+     *
+     * @property addr1 주소
+     * @property addr2 상세 주소
+     * @property zipcode 우편 번호
+     * @property cat1 대분류
+     * @property cat2 중분류
+     * @property cat3 소분류
+     * @property contentid 콘텐츠 ID
+     * @property contenttypeid 콘텐츠 타입 ID
+     * @property createdtime 등록일
+     * @property eventstartdate 행사 시작일
+     * @property eventenddate 행사 종료일
+     * @property firstimage 대표 이미지 (원본)
+     * @property firstimage2 대표 이미지 (썸네일)
+     * @property cpyrhtDivCd 저작권 유형
+     * @property mapx GPS X 좌표
+     * @property mapy GPS Y 좌표
+     * @property mlevel Map Level
+     * @property modifiedtime 수정일
+     * @property areacode 지역
+     * @property sigungucode 시군구 코드
+     * @property tel 전화 번호
+     * @property title 제목
+     * @property lDongRegnCd 법정동 시도 코드
+     * @property lDongSignguCd 법정동 시군구 코드
+     * @property lclsSystm1 분류 체계 대분류
+     * @property lclsSystm2 분류 체계 중분류
+     * @property lclsSystm3 분류 체계 소분류
+     * @property progresstype 진행 상태 정보
+     * @property festivaltype 축제 유형명
+     */
+    data class Item(
+        val addr1: String,
+        val addr2: String,
+        val zipcode: String,
+        val cat1: String,
+        val cat2: String,
+        val cat3: String,
+        val contentid: String,
+        val contenttypeid: String,
+        val createdtime: String,
+        val eventstartdate: String,
+        val eventenddate: String,
+        val firstimage: String,
+        val firstimage2: String,
+        val cpyrhtDivCd: String,
+        val mapx: String,
+        val mapy: String,
+        val mlevel: String,
+        val modifiedtime: String,
+        val areacode: String,
+        val sigungucode: String,
+        val tel: String,
+        val title: String,
+        val lDongRegnCd: String,
+        val lDongSignguCd: String,
+        val lclsSystm1: String,
+        val lclsSystm2: String,
+        val lclsSystm3: String,
+        val progresstype: String,
+        val festivaltype: String,
+    )
+}
+
+private class KorService2SearchFestival2ResponseItemsJsonDeserializer :
+    JsonDeserializer<KorService2SearchFestival2Response.Items>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): KorService2SearchFestival2Response.Items {
+        val jsonNode = p.codec.readTree<JsonNode>(p)
+
+        return when {
+            // 빈 문자열인 경우
+            jsonNode.isTextual && jsonNode.asText().isEmpty() -> {
+                KorService2SearchFestival2Response.Items(emptyList())
+            }
+
+            // 정상
+            jsonNode.isObject && jsonNode.has("item") -> {
+                val itemJsonNode = jsonNode.get("item")
+
+                val items = if (itemJsonNode.isArray) {
+                    p.codec.treeToValue(itemJsonNode, Array<KorService2SearchFestival2Response.Item>::class.java)
+                        .toList()
+                } else {
+                    emptyList()
+                }
+                KorService2SearchFestival2Response.Items(items)
+            }
+
+            else -> {
+                KorService2SearchFestival2Response.Items(emptyList())
+            }
+        }
+    }
+}

--- a/src/main/kotlin/thatline/localup/tourapi/restclient/TourApiRestClient.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/restclient/TourApiRestClient.kt
@@ -161,6 +161,62 @@ class TourApiRestClient(
     }
 
     /**
+     * 한국관광공사_국문 관광정보 서비스_GW: 행사 정보 조회
+     *
+     * @param pageNo 페이지 번호 (선택)
+     * @param numOfRows 한 페이지 결과 수 (선택)
+     * @param eventStartDate 행사 시작일
+     * @param eventEndDate 행사 종료일 (선택)
+     * @param lDongRegnCd 법정동 시도 코드 (선택)
+     * @param lDongSignguCd 법정동 시군구 코드 (선택)
+     * @return [KorService2SearchFestival2Response]
+     *
+     * @see <a href="https://www.data.go.kr/data/15101578/openapi.do">공공데이터포털 API 문서</a>
+     */
+    fun korService2SearchFestival2(
+        pageNo: Long? = null,
+        numOfRows: Long? = null,
+        eventStartDate: String,
+        eventEndDate: String? = null,
+        lDongRegnCd: String? = null,
+        lDongSignguCd: String? = null,
+    ): KorService2SearchFestival2Response {
+        val fromUri = URI.create(
+            "${tourApiProperty.baseUrl}${tourApiProperty.korService2.firstPath}${tourApiProperty.korService2.searchFestival2.secondPath}"
+        )
+
+        val uri = UriComponentsBuilder
+            .fromUri(fromUri)
+            .queryParam("serviceKey", tourApiProperty.korService2.serviceKey)
+            .queryParamIfNotNull("pageNo", pageNo)
+            .queryParamIfNotNull("numOfRows", numOfRows)
+            .queryParam("MobileOS", tourApiProperty.mobileOS)
+            .queryParam("MobileApp", tourApiProperty.mobileApp)
+            .queryParam("_type", "JSON")
+            .queryParam("arrange", KorService2Arrange.TITLE.code)
+            .queryParam("eventStartDate", eventStartDate)
+            .queryParamIfNotNull("eventEndDate", eventEndDate)
+            .queryParamIfNotNull("lDongRegnCd", lDongRegnCd)
+            .queryParamIfNotNull("lDongSignguCd", lDongSignguCd)
+            .build(true)
+            .toUri()
+
+        val response = retrieveTourApi(uri, KorService2SearchFestival2Response::class.java)
+
+        val responseHeader = response.response.header
+
+        if (response.response.header.resultCode != "0000") {
+            throw TourApiKorService2AreaBasedList2Exception(
+                failedUri = uri.toString(),
+                resultCode = responseHeader.resultCode,
+                resultMessage = responseHeader.resultMsg
+            )
+        }
+
+        return response
+    }
+
+    /**
      * 한국관광공사_국문 관광정보 서비스_GW: 소개 정보 조회 15 (축제/공연/행사)
      *
      * @param contentId 콘텐츠 ID

--- a/src/main/kotlin/thatline/localup/tourapi/restclient/TourApiRestClient.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/restclient/TourApiRestClient.kt
@@ -161,6 +161,55 @@ class TourApiRestClient(
     }
 
     /**
+     * 한국관광공사_국문 관광정보 서비스_GW: 소개 정보 조회 15 (축제/공연/행사)
+     *
+     * @param contentId 콘텐츠 ID
+     * @param contentTypeId 콘텐츠 타입 ID, 15로 고정
+     * @param pageNo 페이지 번호 (선택)
+     * @param numOfRows 한 페이지 결과 수 (선택)
+     * @return [KorService2DetailIntro215Response]
+     *
+     * @see <a href="https://www.data.go.kr/data/15101578/openapi.do">공공데이터포털 API 문서</a>
+     */
+    fun korService2DetailIntro215(
+        contentId: String,
+        contentTypeId: String = "15",
+        pageNo: Long? = null,
+        numOfRows: Long? = null,
+    ): KorService2DetailIntro215Response {
+        val fromUri = URI.create(
+            "${tourApiProperty.baseUrl}${tourApiProperty.korService2.firstPath}${tourApiProperty.korService2.detailIntro2.secondPath}"
+        )
+
+        val uri = UriComponentsBuilder
+            .fromUri(fromUri)
+            .queryParam("serviceKey", tourApiProperty.korService2.serviceKey)
+            .queryParam("MobileOS", tourApiProperty.mobileOS)
+            .queryParam("MobileApp", tourApiProperty.mobileApp)
+            .queryParam("_type", "JSON")
+            .queryParam("contentId", contentId)
+            .queryParam("contentTypeId", contentTypeId)
+            .queryParamIfNotNull("pageNo", pageNo)
+            .queryParamIfNotNull("numOfRows", numOfRows)
+            .build(true)
+            .toUri()
+
+        val response = retrieveTourApi(uri, KorService2DetailIntro215Response::class.java)
+
+        val responseHeader = response.response.header
+
+        if (response.response.header.resultCode != "0000") {
+            throw TourApiKorService2AreaBasedList2Exception(
+                failedUri = uri.toString(),
+                resultCode = responseHeader.resultCode,
+                resultMessage = responseHeader.resultMsg
+            )
+        }
+
+        return response
+    }
+
+    /**
      * 한국관광공사_관광지별 연관 관광지 정보: 지역기반 관광지별 연관 관광지 정보 목록 조회
      *
      * @param pageNo 페이지 번호

--- a/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
@@ -166,7 +166,7 @@ class TouristAttractionService(
 
     @Cacheable(
         cacheNames = [CacheObjectName.ONGOING_OR_UPCOMING_SIGUNGU_EVENTS_FROM_TODAY_TO_MONTH_END_INFORMATION],
-        keyGenerator = CacheKeyGeneratorName.SIGUNGU_EVENT,
+        keyGenerator = CacheKeyGeneratorName.ONGOING_OR_UPCOMING_SIGUNGU_EVENTS_FROM_TODAY_TO_MONTH_END,
         sync = true
     )
     fun findOngoingOrUpComingSigunguEventsFromTodayToMonthEnd(

--- a/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
@@ -209,6 +209,18 @@ class TouristAttractionService(
                 }
             }
 
-        return sigunguEventsWithDates
+        // 오늘 날짜(행사 종료일, 제목, 컨텐츠 ID), 진행 중(행사 종료일, 행사 시작일, 제목, 컨텐츠 ID), 진행 예정(행사 시작일, 행사 종료일, 제목, 컨텐츠 ID) 정렬로 진행
+
+        // 1) 오늘 시작 / 나머지
+        val (todayStartEvents, restEvents) = sigunguEventsWithDates.partition { it.startDate == now }
+        // 2) 진행 중 / 진행 예정
+        val (ongoingEvents, upcomingEvents) = restEvents.partition { it.startDate <= now && now <= it.endDate }
+
+        // 3) 섹션별 정렬 후 합치기
+        val sortedEvents = todayStartEvents.sortedWith(compareBy({ it.endDate }, { it.title }, { it.contentId })) +
+                ongoingEvents.sortedWith(compareBy({ it.endDate }, { it.startDate }, { it.title }, { it.contentId })) +
+                upcomingEvents.sortedWith(compareBy({ it.startDate }, { it.endDate }, { it.title }, { it.contentId }))
+
+        return sortedEvents
     }
 }

--- a/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
@@ -10,6 +10,7 @@ import thatline.localup.tourapi.restclient.TourApiRestClient
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
+import java.time.format.DateTimeFormatter
 import kotlin.math.roundToInt
 
 @Service
@@ -114,6 +115,7 @@ class TouristAttractionService(
         )
     }
 
+    @Deprecated("noah: findOngoingOrUpComingSigunguEventsFromTodayToMonthEnd() 메서드로 대체")
     @Cacheable(
         cacheNames = [CacheObjectName.SIGUNGU_EVENT_INFORMATION],
         keyGenerator = CacheKeyGeneratorName.SIGUNGU_EVENT,
@@ -160,5 +162,53 @@ class TouristAttractionService(
             updatedDate = LocalDateTime.now(),
             sigunguEvents = sigunguEvents
         )
+    }
+
+    fun findOngoingOrUpComingSigunguEventsFromTodayToMonthEnd(
+        legalDongSigunguCode: String,
+    ): List<SigunguEventWithDates> {
+        val now = LocalDate.now()
+        val eventStartDate = now.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
+        val eventEndDate = now.withDayOfMonth(now.lengthOfMonth()).format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
+
+        val response1 = tourApiRestClient.korService2SearchFestival2(
+            pageNo = 1,
+            numOfRows = 1,
+            eventStartDate = eventStartDate,
+            eventEndDate = eventEndDate,
+            lDongRegnCd = legalDongSigunguCode.substring(0, 2),
+            lDongSignguCd = legalDongSigunguCode.substring(2, 5),
+        )
+
+        val response2 = tourApiRestClient.korService2SearchFestival2(
+            pageNo = 1,
+            numOfRows = response1.response.body.totalCount,
+            eventStartDate = eventStartDate,
+            eventEndDate = eventEndDate,
+            lDongRegnCd = legalDongSigunguCode.substring(0, 2),
+            lDongSignguCd = legalDongSigunguCode.substring(2, 5),
+        )
+
+        val sigunguEventsWithDates = response2.response.body.items.item
+            .map { it ->
+                with(it) {
+                    SigunguEventWithDates(
+                        contentTypeId = contenttypeid,
+                        contentId = contentid,
+                        title = title,
+                        startDate = LocalDate.parse(eventstartdate, DateTimeFormatter.BASIC_ISO_DATE),
+                        endDate = LocalDate.parse(eventenddate, DateTimeFormatter.BASIC_ISO_DATE),
+                        zipCode = zipcode,
+                        address = listOf(addr1, addr2).filter { it.isNotBlank() }.joinToString(", "),
+                        latitude = mapy.toDouble(),
+                        longitude = mapx.toDouble(),
+                        telephone = tel,
+                        originalImageUrl = firstimage,
+                        thumbnailImageUrl = firstimage2,
+                    )
+                }
+            }
+
+        return sigunguEventsWithDates
     }
 }

--- a/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
@@ -164,9 +164,14 @@ class TouristAttractionService(
         )
     }
 
+    @Cacheable(
+        cacheNames = [CacheObjectName.ONGOING_OR_UPCOMING_SIGUNGU_EVENTS_FROM_TODAY_TO_MONTH_END_INFORMATION],
+        keyGenerator = CacheKeyGeneratorName.SIGUNGU_EVENT,
+        sync = true
+    )
     fun findOngoingOrUpComingSigunguEventsFromTodayToMonthEnd(
         legalDongSigunguCode: String,
-    ): List<SigunguEventWithDates> {
+    ): OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation {
         val now = LocalDate.now()
         val eventStartDate = now.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
         val eventEndDate = now.withDayOfMonth(now.lengthOfMonth()).format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
@@ -221,6 +226,9 @@ class TouristAttractionService(
                 ongoingEvents.sortedWith(compareBy({ it.endDate }, { it.startDate }, { it.title }, { it.contentId })) +
                 upcomingEvents.sortedWith(compareBy({ it.startDate }, { it.endDate }, { it.title }, { it.contentId }))
 
-        return sortedEvents
+        return OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation(
+            updatedDate = LocalDateTime.now(),
+            sigunguEventsWithDates = sortedEvents
+        )
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,6 +27,9 @@ tour-api:
     # 지역기반 관광 정보 조회
     area-based-list2:
       second-path: /areaBasedList2
+    # 행사 정보 조회
+    search-festival2:
+      second-path: /searchFestival2
     # 소개 정보 조회
     detail-intro2:
       second-path: /detailIntro2

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,7 +12,7 @@ tour-api:
   base-url: https://apis.data.go.kr
   mobile-os: WEB
   mobile-app: LocalUp
-    # 한국관광공사_국문 관광정보 서비스_GW
+  # 한국관광공사_국문 관광정보 서비스_GW
   # link: https://www.data.go.kr/data/15101578/openapi.do
   kor-service2:
     first-path: /B551011/KorService2
@@ -27,6 +27,9 @@ tour-api:
     # 지역기반 관광 정보 조회
     area-based-list2:
       second-path: /areaBasedList2
+    # 소개 정보 조회
+    detail-intro2:
+      second-path: /detailIntro2
 
   # 한국관광공사_관광지별 연관 관광지 정보
   # link: https://www.data.go.kr/data/15128560/openapi.do

--- a/src/test/kotlin/thatline/localup/tourapi/KorService2Tests.kt
+++ b/src/test/kotlin/thatline/localup/tourapi/KorService2Tests.kt
@@ -33,4 +33,19 @@ class KorService2Tests {
 
         log.info("\n{}", responseString)
     }
+
+    @Test
+    @DisplayName("한국관광공사_국문 관광정보 서비스_GW,  소개 정보 조회 15 (축제/공연/행사) 실행 테스트")
+    fun runKorService2DetailIntro215() {
+        val response = restClient.korService2DetailIntro215(
+            contentId = "3391612",
+            contentTypeId = "15",
+        )
+
+        val responseString = objectMapper
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(response)
+
+        log.info("\n{}", responseString)
+    }
 }

--- a/src/test/kotlin/thatline/localup/tourapi/KorService2Tests.kt
+++ b/src/test/kotlin/thatline/localup/tourapi/KorService2Tests.kt
@@ -35,6 +35,20 @@ class KorService2Tests {
     }
 
     @Test
+    @DisplayName("한국관광공사_국문 관광정보 서비스_GW: 행사 정보 조회 실행 테스트")
+    fun runKorService2SearchFestival2() {
+        val response = restClient.korService2SearchFestival2(
+            eventStartDate = "20250801"
+        )
+
+        val responseString = objectMapper
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(response)
+
+        log.info("\n{}", responseString)
+    }
+
+    @Test
     @DisplayName("한국관광공사_국문 관광정보 서비스_GW,  소개 정보 조회 15 (축제/공연/행사) 실행 테스트")
     fun runKorService2DetailIntro215() {
         val response = restClient.korService2DetailIntro215(


### PR DESCRIPTION
# feat: dashboard 시군구 이벤트 API 변경 및 적용

## Note

기존에는 "한국관광공사_국문 관광정보 서비스_GW: 지역 기반 관광 정보 조회" API를 사용했으나, 해당 API는 행사 시작일과 종료일 정보를 제공하지 않았습니다. 이로 인해 추가로 "한국관광공사_국문 관광정보 서비스_GW: 소개 정보 조회" API를 호출해야 하는 불편함이 있었습니다.

"한국관광공사_국문 관광정보 서비스_GW: 행사 정보 조회" API로 변경해, 단일 API 호출로 행사 시작일과 종료일 정보를 함께 얻을 수 있도록 개선했습니다.

또한 정렬 기능을 추가했습니다. 가장 먼저 오늘 종료되는 행사(행사 종료일, 제목, 컨텐츠 ID 순), 그 다음 진행 중인 행사(행사 종료일, 행사 시작일, 제목, 컨텐츠 ID 순), 마지막으로 진행 예정인 행사(행사 시작일, 행사 종료일, 제목, 컨텐츠 ID 순)로 정렬됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 대시보드에 ‘오늘부터 월말까지’ 진행 중/예정된 시군구 행사 정보를 새로 제공하여 최신 행사 확인이 쉬워졌습니다.
  - 관광 정보 연동 확대로 행사 목록과 소개 세부 정보가 더 풍부해졌습니다.
- Performance
  - 행사 정보에 일일 만료 캐시를 적용해 로딩 속도와 안정성을 개선했습니다.
- Chores
  - 외부 관광 API 경로 설정을 추가/정비했습니다.
- Tests
  - 신규 API 연동에 대한 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->