### PR TITLE
Feat/chat gpt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
@@ -56,6 +57,10 @@ allOpen {
 tasks.withType<Test> {
     useJUnitPlatform()
 
+    loadDotEnv().forEach { (key, value) -> environment(key, value) }
+}
+
+tasks.named<org.springframework.boot.gradle.tasks.run.BootRun>("bootRun") {
     loadDotEnv().forEach { (key, value) -> environment(key, value) }
 }
 

--- a/src/main/kotlin/thatline/localup/chatgpt/controller/ChatGptController.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/controller/ChatGptController.kt
@@ -1,0 +1,45 @@
+package thatline.localup.chatgpt.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import thatline.localup.chatgpt.dto.ChatSessionRequest
+import thatline.localup.chatgpt.dto.ChatSessionResponse
+import thatline.localup.chatgpt.entity.ChatSession
+import thatline.localup.chatgpt.service.ChatGptService
+import thatline.localup.common.response.BaseResponse
+
+@RestController
+@RequestMapping("/api/chatgpt")
+class ChatGptController(
+    private val chatGptService: ChatGptService
+) {
+    
+    @PostMapping("/chat")
+    fun chat(@RequestBody request: ChatSessionRequest): ResponseEntity<BaseResponse<ChatSessionResponse>> {
+        val response = chatGptService.chat(
+            sessionId = request.sessionId,
+            userId = request.userId,
+            userMessage = request.message
+        )
+        
+        return ResponseEntity.ok(BaseResponse.success(response))
+    }
+    
+    @GetMapping("/sessions/{sessionId}")
+    fun getSession(@PathVariable sessionId: String): ResponseEntity<BaseResponse<ChatSession?>> {
+        val session = chatGptService.getSession(sessionId)
+        
+        return if (session != null) {
+            ResponseEntity.ok(BaseResponse.success(session))
+        } else {
+            ResponseEntity.notFound().build()
+        }
+    }
+    
+    @GetMapping("/users/{userId}/sessions")
+    fun getUserSessions(@PathVariable userId: String): ResponseEntity<BaseResponse<List<ChatSession>>> {
+        val sessions = chatGptService.getUserSessions(userId)
+        
+        return ResponseEntity.ok(BaseResponse.success(sessions))
+    }
+}

--- a/src/main/kotlin/thatline/localup/chatgpt/controller/ChatGptController.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/controller/ChatGptController.kt
@@ -1,10 +1,9 @@
 package thatline.localup.chatgpt.controller
 
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
-import thatline.localup.chatgpt.dto.ChatSessionRequest
-import thatline.localup.chatgpt.dto.ChatSessionResponse
-import thatline.localup.chatgpt.entity.ChatSession
+import thatline.localup.chatgpt.dto.*
 import thatline.localup.chatgpt.service.ChatGptService
 import thatline.localup.common.response.BaseResponse
 
@@ -15,10 +14,13 @@ class ChatGptController(
 ) {
     
     @PostMapping("/chat")
-    fun chat(@RequestBody request: ChatSessionRequest): ResponseEntity<BaseResponse<ChatSessionResponse>> {
+    fun chat(
+        @RequestBody request: ChatSessionRequest,
+        @AuthenticationPrincipal userId: String
+    ): ResponseEntity<BaseResponse<ChatSessionResponse>> {
         val response = chatGptService.chat(
             sessionId = request.sessionId,
-            userId = request.userId,
+            userId = userId,
             userMessage = request.message
         )
         
@@ -26,8 +28,8 @@ class ChatGptController(
     }
     
     @GetMapping("/sessions/{sessionId}")
-    fun getSession(@PathVariable sessionId: String): ResponseEntity<BaseResponse<ChatSession?>> {
-        val session = chatGptService.getSession(sessionId)
+    fun getSession(@PathVariable sessionId: String): ResponseEntity<BaseResponse<ChatSessionDetailResponse?>> {
+        val session = chatGptService.getSessionDetail(sessionId)
         
         return if (session != null) {
             ResponseEntity.ok(BaseResponse.success(session))
@@ -36,10 +38,20 @@ class ChatGptController(
         }
     }
     
-    @GetMapping("/users/{userId}/sessions")
-    fun getUserSessions(@PathVariable userId: String): ResponseEntity<BaseResponse<List<ChatSession>>> {
+    @GetMapping("/sessions")
+    fun getUserSessions(@AuthenticationPrincipal userId: String): ResponseEntity<BaseResponse<List<ChatSessionListResponse>>> {
         val sessions = chatGptService.getUserSessions(userId)
         
         return ResponseEntity.ok(BaseResponse.success(sessions))
+    }
+    
+    @DeleteMapping("/sessions/{sessionId}")
+    fun deleteSession(
+        @PathVariable sessionId: String,
+        @AuthenticationPrincipal userId: String
+    ): ResponseEntity<BaseResponse<String>> {
+        chatGptService.deleteSession(sessionId, userId)
+        
+        return ResponseEntity.ok(BaseResponse.success("세션이 삭제되었습니다."))
     }
 }

--- a/src/main/kotlin/thatline/localup/chatgpt/dto/ChatGptRequest.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/dto/ChatGptRequest.kt
@@ -1,0 +1,22 @@
+package thatline.localup.chatgpt.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class ChatGptRequest(
+    val model: String = "gpt-4o-mini",         // 사용할 OpenAI 모델
+    val messages: List<Message>,               // 대화 메시지 목록
+    val temperature: Double = 0.7,             // 응답 창의성 수준 (0.0~2.0)
+    @JsonProperty("max_tokens") 
+    val maxTokens: Int? = null                 // 최대 응답 토큰 수
+)
+
+data class Message(
+    val role: String,                          // 메시지 역할 (system, user, assistant)
+    val content: String                        // 메시지 내용
+)
+
+data class ChatRequest(
+    val message: String                        // 사용자 입력 메시지
+)

--- a/src/main/kotlin/thatline/localup/chatgpt/dto/ChatGptResponse.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/dto/ChatGptResponse.kt
@@ -1,0 +1,40 @@
+package thatline.localup.chatgpt.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class ChatGptResponse(
+    val id: String,                            // 응답 ID
+    @JsonProperty("object")
+    val objectType: String,                    // 객체 타입 (chat.completion)
+    val created: Long,                         // 생성 타임스탬프
+    val model: String,                         // 사용된 모델 이름
+    val choices: List<Choice>,                 // 응답 선택지 목록
+    val usage: Usage                           // 토큰 사용량 정보
+)
+
+data class Choice(
+    val index: Int,                            // 선택지 인덱스
+    val message: ResponseMessage,              // 응답 메시지
+    @JsonProperty("finish_reason")
+    val finishReason: String?                  // 종료 이유 (stop, length, etc.)
+)
+
+data class ResponseMessage(
+    val role: String,                          // 메시지 역할 (assistant)
+    val content: String?,                      // 메시지 내용
+    val refusal: String? = null,               // 거부 메시지 (안전 정책 위반 시)
+    val annotations: List<Any>? = null         // 추가 주석 정보
+)
+
+data class Usage(
+    @JsonProperty("prompt_tokens")
+    val promptTokens: Int,                     // 입력 프롬프트 토큰 수
+    @JsonProperty("completion_tokens")
+    val completionTokens: Int,                 // 응답 토큰 수
+    @JsonProperty("total_tokens")
+    val totalTokens: Int                       // 총 토큰 수
+)
+
+data class ChatResponse(
+    val reply: String                          // 챗봇 응답 메시지
+)

--- a/src/main/kotlin/thatline/localup/chatgpt/dto/ChatSessionDetailResponse.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/dto/ChatSessionDetailResponse.kt
@@ -1,0 +1,19 @@
+package thatline.localup.chatgpt.dto
+
+import java.time.LocalDateTime
+
+data class ChatSessionDetailResponse(
+    val id: String,                            // 세션 ID
+    val title: String?,                        // 세션 제목
+    val userId: String?,                       // 사용자 ID
+    val messages: List<ChatMessageResponse>,   // 메시지 목록
+    val totalTokens: Int,                      // 총 토큰 사용량
+    val createdAt: LocalDateTime,              // 생성 시간
+    val updatedAt: LocalDateTime               // 마지막 수정 시간
+)
+
+data class ChatMessageResponse(
+    val role: String,                          // 메시지 역할 (user, assistant)
+    val content: String,                       // 메시지 내용
+    val timestamp: LocalDateTime               // 메시지 시간
+)

--- a/src/main/kotlin/thatline/localup/chatgpt/dto/ChatSessionListResponse.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/dto/ChatSessionListResponse.kt
@@ -1,0 +1,13 @@
+package thatline.localup.chatgpt.dto
+
+import java.time.LocalDateTime
+
+data class ChatSessionListResponse(
+    val id: String,                            // 세션 ID
+    val title: String,                         // 세션 제목
+    val userId: String?,                       // 사용자 ID
+    val totalMessages: Int,                    // 총 메시지 수
+    val totalTokens: Int,                      // 총 토큰 사용량
+    val createdAt: LocalDateTime,              // 생성 시간
+    val updatedAt: LocalDateTime               // 마지막 수정 시간
+)

--- a/src/main/kotlin/thatline/localup/chatgpt/dto/ChatSessionResponse.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/dto/ChatSessionResponse.kt
@@ -1,0 +1,14 @@
+package thatline.localup.chatgpt.dto
+
+data class ChatSessionResponse(
+    val sessionId: String,                     // 세션 ID
+    val reply: String,                         // AI 응답 메시지
+    val title: String? = null,                 // 세션 제목
+    val totalMessages: Int,                    // 총 메시지 수
+    val totalTokens: Int                       // 총 사용 토큰 수
+)
+
+data class ChatSessionRequest(
+    val sessionId: String? = null,             // 기존 세션 ID (이어서 대화하기)
+    val message: String                        // 사용자 메시지
+)

--- a/src/main/kotlin/thatline/localup/chatgpt/entity/ChatSession.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/entity/ChatSession.kt
@@ -1,0 +1,24 @@
+package thatline.localup.chatgpt.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+
+@Document(collection = "chat_sessions")
+data class ChatSession(
+    @Id
+    val id: String? = null,                                    // MongoDB 자동 생성 ID
+    val userId: String?,                                       // 사용자 ID (로그인 사용자인 경우)
+    val title: String? = null,                                 // 대화 세션 제목 (자동 생성 또는 사용자 지정)
+    val messages: MutableList<ChatMessage> = mutableListOf(),  // 대화 메시지 목록
+    val createdAt: LocalDateTime = LocalDateTime.now(),        // 세션 생성 시간
+    val updatedAt: LocalDateTime = LocalDateTime.now(),        // 세션 최종 수정 시간
+    val totalTokens: Int = 0                                   // 총 사용된 토큰 수
+)
+
+data class ChatMessage(
+    val role: String,                                          // 메시지 역할 (user, assistant, system)
+    val content: String,                                       // 메시지 내용
+    val tokens: Int = 0,                                        // 메시지에 사용된 토큰 수
+    val timestamp: LocalDateTime = LocalDateTime.now()         // 메시지 생성 시간
+)

--- a/src/main/kotlin/thatline/localup/chatgpt/exception/ChatGptException.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/exception/ChatGptException.kt
@@ -1,0 +1,6 @@
+package thatline.localup.chatgpt.exception
+
+class ChatGptException(
+    message: String,
+    cause: Throwable? = null
+) : RuntimeException(message, cause)

--- a/src/main/kotlin/thatline/localup/chatgpt/repository/ChatSessionRepository.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/repository/ChatSessionRepository.kt
@@ -1,0 +1,10 @@
+package thatline.localup.chatgpt.repository
+
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import thatline.localup.chatgpt.entity.ChatSession
+
+@Repository
+interface ChatSessionRepository : MongoRepository<ChatSession, String> {
+    fun findByUserId(userId: String): List<ChatSession>
+}

--- a/src/main/kotlin/thatline/localup/chatgpt/restclient/ChatGptRestClient.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/restclient/ChatGptRestClient.kt
@@ -1,0 +1,60 @@
+package thatline.localup.chatgpt.restclient
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import thatline.localup.chatgpt.dto.ChatGptRequest
+import thatline.localup.chatgpt.dto.ChatGptResponse
+import thatline.localup.chatgpt.exception.ChatGptException
+import java.util.concurrent.TimeUnit
+
+@Component
+class ChatGptRestClient(
+    private val objectMapper: ObjectMapper,
+    @Value("\${openai.api-key}")
+    private val apiKey: String,
+    @Value("\${openai.api-url:https://api.openai.com/v1/chat/completions}")
+    private val apiUrl: String
+) {
+    private val log = LoggerFactory.getLogger(this::class.java)
+    
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .writeTimeout(60, TimeUnit.SECONDS)
+        .build()
+    
+    fun chat(request: ChatGptRequest): ChatGptResponse {
+        try {
+            val requestBody = objectMapper.writeValueAsString(request)
+                .toRequestBody("application/json".toMediaType())
+            
+            val httpRequest = Request.Builder()
+                .url(apiUrl)
+                .header("Authorization", "Bearer $apiKey")
+                .header("Content-Type", "application/json")
+                .post(requestBody)
+                .build()
+            
+            client.newCall(httpRequest).execute().use { response ->
+                if (!response.isSuccessful) {
+                    log.error("ChatGPT API 호출 실패: ${response.code} - ${response.message}")
+                    throw ChatGptException("ChatGPT API 호출 실패: ${response.message}")
+                }
+                
+                val responseBody = response.body?.string() 
+                    ?: throw ChatGptException("응답 본문이 비어있습니다")
+                
+                return objectMapper.readValue(responseBody, ChatGptResponse::class.java)
+            }
+        } catch (e: Exception) {
+            log.error("ChatGPT API 호출 중 오류 발생", e)
+            throw ChatGptException("ChatGPT API 호출 중 오류 발생: ${e.message}", e)
+        }
+    }
+}

--- a/src/main/kotlin/thatline/localup/chatgpt/restclient/ChatGptRestClient.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/restclient/ChatGptRestClient.kt
@@ -31,8 +31,8 @@ class ChatGptRestClient(
     
     fun chat(request: ChatGptRequest): ChatGptResponse {
         try {
-            val requestBody = objectMapper.writeValueAsString(request)
-                .toRequestBody("application/json".toMediaType())
+            val requestBodyJson = objectMapper.writeValueAsString(request)
+            val requestBody = requestBodyJson.toRequestBody("application/json".toMediaType())
             
             val httpRequest = Request.Builder()
                 .url(apiUrl)
@@ -42,13 +42,17 @@ class ChatGptRestClient(
                 .build()
             
             client.newCall(httpRequest).execute().use { response ->
+                val responseBody = response.body?.string()
+                
                 if (!response.isSuccessful) {
                     log.error("ChatGPT API 호출 실패: ${response.code} - ${response.message}")
-                    throw ChatGptException("ChatGPT API 호출 실패: ${response.message}")
+                    log.error("응답 본문: $responseBody")
+                    throw ChatGptException("ChatGPT API 호출 실패: ${response.message} - $responseBody")
                 }
                 
-                val responseBody = response.body?.string() 
-                    ?: throw ChatGptException("응답 본문이 비어있습니다")
+                if (responseBody.isNullOrBlank()) {
+                    throw ChatGptException("응답 본문이 비어있습니다")
+                }
                 
                 return objectMapper.readValue(responseBody, ChatGptResponse::class.java)
             }

--- a/src/main/kotlin/thatline/localup/chatgpt/service/ChatGptService.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/service/ChatGptService.kt
@@ -1,5 +1,6 @@
 package thatline.localup.chatgpt.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -16,9 +17,23 @@ class ChatGptService(
     private val chatGptRestClient: ChatGptRestClient,
     private val chatSessionRepository: ChatSessionRepository,
     private val tokenCounter: TokenCounter,
+    private val objectMapper: ObjectMapper,
     @Value("\${openai.max-context-tokens:3000}")
-    private val maxContextTokens: Int
+    private val maxContextTokens: Int,
+    @Value("\${openai.model:gpt-4o-mini}")
+    private val defaultModel: String,
+    @Value("\${openai.temperature:0.7}")
+    private val defaultTemperature: Double,
+    @Value("\${openai.max-tokens:1000}")
+    private val defaultMaxTokens: Int
 ) {
+    companion object {
+        private const val TITLE_MAX_LENGTH = 30
+        private const val TITLE_PROMPT_MAX_TOKENS = 50
+        private const val NEW_SESSION_MESSAGE_COUNT = 2
+        private const val DEFAULT_SESSION_TITLE = "새 대화"
+    }
+    
     private val log = LoggerFactory.getLogger(this::class.java)
     
     private val systemPrompt = """
@@ -29,14 +44,41 @@ class ChatGptService(
     """.trimIndent()
     
     fun chat(sessionId: String?, userId: String?, userMessage: String): ChatSessionResponse {
-        val session = if (sessionId != null) {
+        val session = getOrCreateSession(sessionId, userId)
+        
+        addUserMessage(session, userMessage)
+        
+        return try {
+            val response = sendChatRequest(session.messages)
+            val reply = extractReply(response)
+            
+            if (reply.isNullOrBlank()) {
+                return createErrorResponse(session, "죄송합니다. 응답을 생성할 수 없습니다.")
+            }
+            
+            addAssistantMessage(session, reply)
+            
+            val sessionTitle = determineSessionTitle(session, userMessage, reply)
+            val savedSession = saveSession(session, sessionTitle)
+            
+            createSuccessResponse(savedSession, reply)
+        } catch (e: Exception) {
+            log.error("ChatGPT 서비스 처리 중 오류 발생", e)
+            createErrorResponse(session, "죄송합니다. 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")
+        }
+    }
+    
+    private fun getOrCreateSession(sessionId: String?, userId: String?): ChatSession {
+        return if (sessionId != null) {
             chatSessionRepository.findById(sessionId).orElseGet {
                 createNewSession(userId)
             }
         } else {
             createNewSession(userId)
         }
-        
+    }
+    
+    private fun addUserMessage(session: ChatSession, userMessage: String) {
         val userMessageTokens = tokenCounter.countTokens(userMessage)
         session.messages.add(
             ChatMessage(
@@ -45,61 +87,89 @@ class ChatGptService(
                 tokens = userMessageTokens
             )
         )
+    }
+    
+    private fun sendChatRequest(messages: List<ChatMessage>): ChatGptResponse {
+        val messagesToSend = optimizeMessages(messages)
+        val apiMessages = buildApiMessages(messagesToSend)
         
-        val messagesToSend = optimizeMessages(session.messages)
+        val request = ChatGptRequest(
+            model = defaultModel,
+            messages = apiMessages,
+            temperature = defaultTemperature,
+            maxTokens = defaultMaxTokens
+        )
         
+        return chatGptRestClient.chat(request)
+    }
+    
+    private fun buildApiMessages(messages: List<ChatMessage>): List<Message> {
         val apiMessages = mutableListOf(
             Message(role = "system", content = systemPrompt)
         )
         apiMessages.addAll(
-            messagesToSend.map { Message(role = it.role, content = it.content) }
+            messages.map { Message(role = it.role, content = it.content) }
         )
-        
-        val request = ChatGptRequest(
-            model = "gpt-5-nano",
-            messages = apiMessages,
-            temperature = 0.7,
-            maxTokens = 1000
-        )
-        
-        return try {
-            val response = chatGptRestClient.chat(request)
-            val reply = response.choices.firstOrNull()?.message?.content 
-                ?: "죄송합니다. 응답을 생성할 수 없습니다."
-            
-            val assistantTokens = tokenCounter.countTokens(reply)
-            session.messages.add(
-                ChatMessage(
-                    role = "assistant",
-                    content = reply,
-                    tokens = assistantTokens
-                )
-            )
-            
-            val updatedSession = session.copy(
-                updatedAt = LocalDateTime.now(),
-                totalTokens = session.messages.sumOf { it.tokens }
-            )
-            
-            val savedSession = chatSessionRepository.save(updatedSession)
-            
-            log.info("ChatGPT 응답 생성 완료 - 세션 ID: ${savedSession.id}, 총 토큰: ${savedSession.totalTokens}")
-            
-            ChatSessionResponse(
-                sessionId = savedSession.id!!,
-                reply = reply,
-                totalMessages = savedSession.messages.size,
-                totalTokens = savedSession.totalTokens
-            )
-        } catch (e: Exception) {
-            log.error("ChatGPT 서비스 처리 중 오류 발생", e)
-            ChatSessionResponse(
-                sessionId = session.id ?: "",
-                reply = "죄송합니다. 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
-                totalMessages = session.messages.size,
-                totalTokens = session.totalTokens
-            )
+        return apiMessages
+    }
+    
+    private fun extractReply(response: ChatGptResponse): String? {
+        return response.choices.firstOrNull()?.message?.content?.also { reply ->
+            if (reply.isNullOrBlank()) {
+                log.warn("ChatGPT 응답이 비어있습니다")
+            }
         }
+    }
+    
+    private fun addAssistantMessage(session: ChatSession, reply: String) {
+        val assistantTokens = tokenCounter.countTokens(reply)
+        session.messages.add(
+            ChatMessage(
+                role = "assistant",
+                content = reply,
+                tokens = assistantTokens
+            )
+        )
+    }
+    
+    private fun determineSessionTitle(session: ChatSession, userMessage: String, reply: String): String? {
+        return if (session.title == null && session.messages.size == NEW_SESSION_MESSAGE_COUNT) {
+            generateSessionTitle(userMessage, reply)
+        } else {
+            session.title
+        }
+    }
+    
+    private fun saveSession(session: ChatSession, title: String?): ChatSession {
+        val updatedSession = session.copy(
+            title = title,
+            updatedAt = LocalDateTime.now(),
+            totalTokens = session.messages.sumOf { it.tokens }
+        )
+        
+        return chatSessionRepository.save(updatedSession).also {
+            log.info("ChatGPT 응답 생성 완료 - 세션 ID: ${it.id}, 총 토큰: ${it.totalTokens}")
+        }
+    }
+    
+    private fun createSuccessResponse(session: ChatSession, reply: String): ChatSessionResponse {
+        return ChatSessionResponse(
+            sessionId = session.id!!,
+            reply = reply,
+            title = session.title,
+            totalMessages = session.messages.size,
+            totalTokens = session.totalTokens
+        )
+    }
+    
+    private fun createErrorResponse(session: ChatSession, errorMessage: String): ChatSessionResponse {
+        return ChatSessionResponse(
+            sessionId = session.id ?: "",
+            reply = errorMessage,
+            title = session.title,
+            totalMessages = session.messages.size,
+            totalTokens = session.totalTokens
+        )
     }
     
     fun createNewSession(userId: String?): ChatSession {
@@ -110,8 +180,39 @@ class ChatGptService(
         return chatSessionRepository.findById(sessionId).orElse(null)
     }
     
-    fun getUserSessions(userId: String): List<ChatSession> {
-        return chatSessionRepository.findByUserId(userId)
+    fun getUserSessions(userId: String): List<ChatSessionListResponse> {
+        return chatSessionRepository.findByUserId(userId).map { session ->
+            ChatSessionListResponse(
+                id = session.id!!,
+                title = session.title ?: DEFAULT_SESSION_TITLE,
+                userId = session.userId,
+                totalMessages = session.messages.size,
+                totalTokens = session.totalTokens,
+                createdAt = session.createdAt,
+                updatedAt = session.updatedAt
+            )
+        }
+    }
+    
+    fun getSessionDetail(sessionId: String): ChatSessionDetailResponse? {
+        val session = chatSessionRepository.findById(sessionId).orElse(null)
+        return session?.let {
+            ChatSessionDetailResponse(
+                id = it.id!!,
+                title = it.title,
+                userId = it.userId,
+                messages = it.messages.map { message ->
+                    ChatMessageResponse(
+                        role = message.role,
+                        content = message.content,
+                        timestamp = message.timestamp
+                    )
+                },
+                totalTokens = it.totalTokens,
+                createdAt = it.createdAt,
+                updatedAt = it.updatedAt
+            )
+        }
     }
     
     private fun optimizeMessages(messages: List<ChatMessage>): List<ChatMessage> {
@@ -137,5 +238,54 @@ class ChatGptService(
         }
         
         return optimizedMessages
+    }
+    
+    private fun generateSessionTitle(userMessage: String, assistantReply: String): String {
+        return try {
+            val titlePrompt = """
+                사용자 메시지: "$userMessage"
+                
+                위 메시지의 주제를 10자 이내의 짧은 한글 제목으로 만들어주세요.
+                JSON 형식으로 응답: {"title": "제목"}
+            """.trimIndent()
+            
+            val request = ChatGptRequest(
+                model = defaultModel,
+                messages = listOf(
+                    Message(role = "system", content = "대화 제목을 생성하는 도우미입니다."),
+                    Message(role = "user", content = titlePrompt)
+                ),
+                temperature = defaultTemperature,
+                maxTokens = TITLE_PROMPT_MAX_TOKENS
+            )
+            
+            val response = chatGptRestClient.chat(request)
+            val content = response.choices.firstOrNull()?.message?.content?.trim()
+            
+            if (!content.isNullOrBlank()) {
+                try {
+                    val jsonNode = objectMapper.readTree(content)
+                    val title = jsonNode.get("title")?.asText()
+                    
+                    if (!title.isNullOrBlank()) {
+                        return title.take(TITLE_MAX_LENGTH)
+                    }
+                } catch (e: Exception) {
+                    log.warn("제목 생성 JSON 파싱 실패: $content")
+                }
+            }
+            
+            DEFAULT_SESSION_TITLE
+        } catch (e: Exception) {
+            log.error("세션 제목 생성 중 오류 발생", e)
+            DEFAULT_SESSION_TITLE
+        }
+    }
+    
+    fun deleteSession(sessionId: String, userId: String) {
+        val session = chatSessionRepository.findById(sessionId).orElse(null)
+        if (session != null && session.userId == userId) {
+            chatSessionRepository.deleteById(sessionId)
+        }
     }
 }

--- a/src/main/kotlin/thatline/localup/chatgpt/service/ChatGptService.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/service/ChatGptService.kt
@@ -1,0 +1,141 @@
+package thatline.localup.chatgpt.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import thatline.localup.chatgpt.dto.*
+import thatline.localup.chatgpt.entity.ChatMessage
+import thatline.localup.chatgpt.entity.ChatSession
+import thatline.localup.chatgpt.repository.ChatSessionRepository
+import thatline.localup.chatgpt.restclient.ChatGptRestClient
+import thatline.localup.chatgpt.util.TokenCounter
+import java.time.LocalDateTime
+
+@Service
+class ChatGptService(
+    private val chatGptRestClient: ChatGptRestClient,
+    private val chatSessionRepository: ChatSessionRepository,
+    private val tokenCounter: TokenCounter,
+    @Value("\${openai.max-context-tokens:3000}")
+    private val maxContextTokens: Int
+) {
+    private val log = LoggerFactory.getLogger(this::class.java)
+    
+    private val systemPrompt = """
+        당신은 친절하고 도움이 되는 AI 어시스턴트입니다.
+        사용자의 질문에 정확하고 유용한 답변을 제공해주세요.
+        답변은 명확하고 이해하기 쉽게 작성해주세요.
+        한국어로 대화를 진행합니다.
+    """.trimIndent()
+    
+    fun chat(sessionId: String?, userId: String?, userMessage: String): ChatSessionResponse {
+        val session = if (sessionId != null) {
+            chatSessionRepository.findById(sessionId).orElseGet {
+                createNewSession(userId)
+            }
+        } else {
+            createNewSession(userId)
+        }
+        
+        val userMessageTokens = tokenCounter.countTokens(userMessage)
+        session.messages.add(
+            ChatMessage(
+                role = "user",
+                content = userMessage,
+                tokens = userMessageTokens
+            )
+        )
+        
+        val messagesToSend = optimizeMessages(session.messages)
+        
+        val apiMessages = mutableListOf(
+            Message(role = "system", content = systemPrompt)
+        )
+        apiMessages.addAll(
+            messagesToSend.map { Message(role = it.role, content = it.content) }
+        )
+        
+        val request = ChatGptRequest(
+            model = "gpt-5-nano",
+            messages = apiMessages,
+            temperature = 0.7,
+            maxTokens = 1000
+        )
+        
+        return try {
+            val response = chatGptRestClient.chat(request)
+            val reply = response.choices.firstOrNull()?.message?.content 
+                ?: "죄송합니다. 응답을 생성할 수 없습니다."
+            
+            val assistantTokens = tokenCounter.countTokens(reply)
+            session.messages.add(
+                ChatMessage(
+                    role = "assistant",
+                    content = reply,
+                    tokens = assistantTokens
+                )
+            )
+            
+            val updatedSession = session.copy(
+                updatedAt = LocalDateTime.now(),
+                totalTokens = session.messages.sumOf { it.tokens }
+            )
+            
+            val savedSession = chatSessionRepository.save(updatedSession)
+            
+            log.info("ChatGPT 응답 생성 완료 - 세션 ID: ${savedSession.id}, 총 토큰: ${savedSession.totalTokens}")
+            
+            ChatSessionResponse(
+                sessionId = savedSession.id!!,
+                reply = reply,
+                totalMessages = savedSession.messages.size,
+                totalTokens = savedSession.totalTokens
+            )
+        } catch (e: Exception) {
+            log.error("ChatGPT 서비스 처리 중 오류 발생", e)
+            ChatSessionResponse(
+                sessionId = session.id ?: "",
+                reply = "죄송합니다. 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+                totalMessages = session.messages.size,
+                totalTokens = session.totalTokens
+            )
+        }
+    }
+    
+    fun createNewSession(userId: String?): ChatSession {
+        return ChatSession(userId = userId)
+    }
+    
+    fun getSession(sessionId: String): ChatSession? {
+        return chatSessionRepository.findById(sessionId).orElse(null)
+    }
+    
+    fun getUserSessions(userId: String): List<ChatSession> {
+        return chatSessionRepository.findByUserId(userId)
+    }
+    
+    private fun optimizeMessages(messages: List<ChatMessage>): List<ChatMessage> {
+        if (messages.isEmpty()) return emptyList()
+        
+        val optimizedMessages = mutableListOf<ChatMessage>()
+        var currentTokens = tokenCounter.countTokens(systemPrompt)
+        
+        for (message in messages.reversed()) {
+            val messageTokens = message.tokens
+            if (currentTokens + messageTokens > maxContextTokens) {
+                break
+            }
+            optimizedMessages.add(0, message)
+            currentTokens += messageTokens
+        }
+        
+        if (optimizedMessages.isNotEmpty() && optimizedMessages.first().role != "user") {
+            val firstUserIndex = optimizedMessages.indexOfFirst { it.role == "user" }
+            if (firstUserIndex > 0) {
+                return optimizedMessages.subList(firstUserIndex, optimizedMessages.size)
+            }
+        }
+        
+        return optimizedMessages
+    }
+}

--- a/src/main/kotlin/thatline/localup/chatgpt/util/TokenCounter.kt
+++ b/src/main/kotlin/thatline/localup/chatgpt/util/TokenCounter.kt
@@ -1,0 +1,22 @@
+package thatline.localup.chatgpt.util
+
+import org.springframework.stereotype.Component
+import kotlin.math.ceil
+
+@Component
+class TokenCounter {
+    
+    fun countTokens(text: String): Int {
+        val words = text.split(Regex("\\s+"))
+        val englishWords = words.count { it.matches(Regex("[a-zA-Z]+")) }
+        val koreanChars = text.count { it in '가'..'힣' }
+        
+        return ceil(englishWords * 1.3 + koreanChars * 0.5).toInt()
+    }
+    
+    fun countMessageTokens(messages: List<Pair<String, String>>): Int {
+        return messages.sumOf { (role, content) ->
+            countTokens(role) + countTokens(content) + 4
+        }
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -50,3 +50,12 @@ etc-api:
   kma:
     vilage-fcst-info-service:
       service-key: ${VILAGE_FCST_INFO_SERVICE_KEY}
+
+# OpenAI ChatGPT API 설정
+openai:
+  api-key: ${OPENAI_API_KEY}                           # OpenAI API 키 (환경변수로 관리)
+  api-url: https://api.openai.com/v1/chat/completions  # ChatGPT API 엔드포인트
+  model: gpt-4o-mini                                   # 사용할 GPT 모델 (gpt-4o-mini, gpt-4, gpt-3.5-turbo 등)
+  temperature: 0.7                                     # 응답 창의성 수준 (0.0~2.0, 낮을수록 일관성 높음)
+  max-tokens: 1000                                     # 응답 최대 토큰 수 (응답 길이 제한)
+  max-context-tokens: 3000                             # 컨텍스트 최대 토큰 수 (대화 기록 제한)


### PR DESCRIPTION
# Pull Request: ChatGPT 대화 기능, AI 솔루션 페이지 API 

## 📋 개요
LocalUp 애플리케이션에 OpenAI ChatGPT API를 활용한 AI 대화 기능을 추가합니다. 사용자는 AI 어시스턴트와 대화를 나누고, 대화 내역을 관리할 수 있습니다.

## 🎯 구현 목적
- 사용자에게 AI 기반 대화형 서비스 제공
- 관광 정보 및 일반 질문에 대한 즉각적인 응답 지원
- 대화 세션 관리를 통한 연속적인 대화 경험 제공

## ✨ 주요 기능

### 1. 대화 기능
- **새 대화 시작**: 인증된 사용자가 새로운 대화 세션 생성
- **대화 이어가기**: 기존 세션 ID를 통한 연속 대화
- **자동 제목 생성**: 첫 대화 시 AI가 자동으로 대화 제목 생성

### 2. 세션 관리
- **세션 목록 조회**: 사용자별 모든 대화 세션 목록 확인
- **세션 상세 조회**: 특정 세션의 전체 대화 내역 조회
- **세션 삭제**: 불필요한 대화 세션 삭제

### 3. 토큰 최적화
- 메시지별 토큰 수 계산 및 추적
- 컨텍스트 윈도우 관리 (최대 3000 토큰)
- 긴 대화 시 자동으로 이전 메시지 최적화

## 🏗️ 기술 구현

### 아키텍처
```
Controller → Service → RestClient → OpenAI API
                ↓
            Repository → MongoDB
```

### 주요 컴포넌트

#### 1. Entity & DTO
- `ChatSession`: MongoDB 대화 세션 엔티티
- `ChatMessage`: 개별 메시지 정보
- `ChatGptRequest/Response`: OpenAI API 통신 DTO
- `ChatSessionResponse`: 대화 응답 DTO

#### 2. Service Layer
- **ChatGptService**: 핵심 비즈니스 로직
  - 세션 관리 (생성/조회/삭제)
  - OpenAI API 호출 및 응답 처리
  - 자동 제목 생성
  - 토큰 최적화

#### 3. RestClient
- **ChatGptRestClient**: OpenAI API 통신
  - OkHttp3 기반 HTTP 클라이언트
  - 에러 핸들링 및 타임아웃 설정

#### 4. Repository
- **ChatSessionRepository**: MongoDB 데이터 접근
  - 사용자별 세션 조회
  - 세션 저장 및 삭제

## 📡 API 엔드포인트

### 대화 API
```http
POST /api/chatgpt/chat
Authorization: Bearer {token}
Content-Type: application/json

{
  "sessionId": "optional-session-id",
  "message": "사용자 메시지"
}

Response:
{
  "code": "SUCCESS",
  "data": {
    "sessionId": "생성된_세션_ID",
    "reply": "AI 응답",
    "title": "대화 제목",
    "totalMessages": 2,
    "totalTokens": 150
  }
}
```

### 세션 목록 조회
```http
GET /api/chatgpt/sessions
Authorization: Bearer {token}

Response:
{
  "code": "SUCCESS",
  "data": [
    {
      "id": "세션_ID",
      "title": "대화 제목",
      "userId": "사용자_ID",
      "totalMessages": 4,
      "totalTokens": 500,
      "createdAt": "2024-01-01T10:00:00",
      "updatedAt": "2024-01-01T11:00:00"
    }
  ]
}
```

### 세션 상세 조회
```http
GET /api/chatgpt/sessions/{sessionId}
Authorization: Bearer {token}

Response:
{
  "code": "SUCCESS",
  "data": {
    "id": "세션_ID",
    "title": "대화 제목",
    "messages": [
      {
        "role": "user",
        "content": "사용자 메시지",
        "timestamp": "2024-01-01T10:00:00"
      },
      {
        "role": "assistant",
        "content": "AI 응답",
        "timestamp": "2024-01-01T10:00:05"
      }
    ],
    "totalTokens": 500
  }
}
```

### 세션 삭제
```http
DELETE /api/chatgpt/sessions/{sessionId}
Authorization: Bearer {token}

Response:
{
  "code": "SUCCESS",
  "message": "세션이 삭제되었습니다."
}
```

## ⚙️ 설정

### application-local.yaml
```yaml
# OpenAI ChatGPT API 설정
openai:
  api-key: ${OPENAI_API_KEY}                           # OpenAI API 키
  api-url: https://api.openai.com/v1/chat/completions  # API 엔드포인트
  model: gpt-4o-mini                                   # 사용 모델
  temperature: 0.7                                     # 창의성 수준 (0.0~2.0)
  max-tokens: 1000                                     # 응답 최대 토큰
  max-context-tokens: 3000                             # 컨텍스트 최대 토큰
```

### 환경변수 설정
`.env` 파일 생성:
```bash
OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxx
```

## 🔒 보안 및 권한
- 모든 ChatGPT API는 인증 필요 (Spring Security 통합)
- 사용자는 자신의 세션만 조회/삭제 가능
- API 키는 환경변수로 관리

## 📦 의존성 추가
```kotlin
// build.gradle.kts
implementation("com.squareup.okhttp3:okhttp:4.12.0")
```

## 🧪 테스트 방법

### 1. 환경 설정
1. `.env` 파일에 OPENAI_API_KEY 설정
2. MongoDB 실행 확인
3. 애플리케이션 실행: `./gradlew bootRun`

### 2. API 테스트 시나리오

#### 시나리오 1: 새 대화 시작
```bash
# 로그인
POST /api/auth/sign-in
{
  "email": "test@gmail.com",
  "password": "test_password"
}

# 새 대화 시작
POST /api/chatgpt/chat
{
  "message": "안녕하세요, 테스트입니다"
}
```

#### 시나리오 2: 대화 이어가기
```bash
# 기존 세션으로 대화 계속
POST /api/chatgpt/chat
{
  "sessionId": "이전_응답의_sessionId",
  "message": "오늘 날씨는 어때?"
}
```

#### 시나리오 3: 세션 관리
```bash
# 세션 목록 조회
GET /api/chatgpt/sessions

# 특정 세션 상세 조회
GET /api/chatgpt/sessions/{sessionId}

# 세션 삭제
DELETE /api/chatgpt/sessions/{sessionId}
```

## 📊 성능 고려사항
- **토큰 최적화**: 대화가 길어질 경우 오래된 메시지 자동 제거
- **응답 시간**: OpenAI API 타임아웃 60초 설정
- **에러 처리**: API 실패 시 사용자 친화적 에러 메시지 반환

## 🔄 향후 개선 사항
- [ ] 대화 내용 검색 기능
- [ ] 첨부 파일 포함 대화 기능 
- [ ] 다양한 AI 모델 선택 옵션
- [ ] 대화 내용 Export 기능 (PDF, TXT)
- [ ] Rate Limiting 적용, 현재 API 비용 제한 미적용 

## 📝 주의사항
- OpenAI API 키가 필요합니다
- API 사용량에 따른 비용이 발생할 수 있습니다
- 현재 gpt-4o-mini 모델을 사용하며, 필요시 설정에서 변경 가능합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - ChatGPT 연동 대화 기능 추가: 메시지 전송, 세션 생성/유지, 사용자별 세션 목록·상세 조회, 세션 삭제 지원
  - 첫 대화 이후 한국어 자동 제목 생성 및 총 메시지/토큰 수 제공
  - 안정적인 오류 응답 처리로 사용자 피드백 개선
- 작업
  - 실행 시 .env 환경변수 자동 로드(bootRun) 구성
  - OpenAI 연동을 위한 로컬 환경 설정값 추가 (API 키, 모델, 토큰 한도 등)
  - 네트워크 클라이언트 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->