### PR TITLE
refactor: business mongo db entity

### DIFF
--- a/src/main/kotlin/thatline/localup/user/entity/BusinessMongoDbEntity.kt
+++ b/src/main/kotlin/thatline/localup/user/entity/BusinessMongoDbEntity.kt
@@ -48,4 +48,40 @@ class BusinessMongoDbEntity(
 
     // 주요 고객층 (선택)
     val customerSegments: Set<CustomerSegment>,
-) : BaseMongoDbEntity(id, createdDate, lastModifiedDate)
+) : BaseMongoDbEntity(id, createdDate, lastModifiedDate) {
+    fun copy(
+        id: String = this.id,
+        createdDate: LocalDateTime = this.createdDate,
+        lastModifiedDate: LocalDateTime = this.lastModifiedDate,
+        name: String = this.name,
+        sigunguCode: String = this.sigunguCode,
+        zipCode: String = this.zipCode,
+        address: String = this.address,
+        addressDetail: String? = this.addressDetail,
+        latitude: Double = this.latitude,
+        longitude: Double = this.longitude,
+        type: String = this.type,
+        item: String = this.item,
+        averageOrderAmount: Double = this.averageOrderAmount,
+        seatCount: Int = this.seatCount,
+        customerSegments: Set<CustomerSegment> = this.customerSegments,
+    ): BusinessMongoDbEntity {
+        return BusinessMongoDbEntity(
+            id = id,
+            createdDate = createdDate,
+            lastModifiedDate = lastModifiedDate,
+            name = name,
+            sigunguCode = sigunguCode,
+            zipCode = zipCode,
+            address = address,
+            addressDetail = addressDetail,
+            latitude = latitude,
+            longitude = longitude,
+            type = type,
+            item = item,
+            averageOrderAmount = averageOrderAmount,
+            seatCount = seatCount,
+            customerSegments = customerSegments.toSet(),
+        )
+    }
+}

--- a/src/main/kotlin/thatline/localup/user/service/UserService.kt
+++ b/src/main/kotlin/thatline/localup/user/service/UserService.kt
@@ -119,9 +119,7 @@ class UserService(
         val foundBusiness = businessRepository.findById(businessId)
             .orElseThrow { BusinessNotRegisteredException() }
 
-        val updatedBusiness = BusinessMongoDbEntity(
-            id = businessId,
-            createdDate = foundBusiness.createdDate,
+        val updatedBusiness = foundBusiness.copy(
             lastModifiedDate = LocalDateTime.now(),
             name = businessName,
             sigunguCode = businessSigunguCode,

--- a/src/test/kotlin/thatline/localup/mongodb/MongoDbEntityCopyTests.kt
+++ b/src/test/kotlin/thatline/localup/mongodb/MongoDbEntityCopyTests.kt
@@ -1,0 +1,85 @@
+package thatline.localup.mongodb
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
+import org.springframework.test.context.TestPropertySource
+import thatline.localup.user.entity.BusinessMongoDbEntity
+import thatline.localup.user.entity.CustomerSegment
+import thatline.localup.user.repository.BusinessMongoDbRepository
+
+@DataMongoTest
+@TestPropertySource(properties = ["spring.data.mongodb.database=test"])
+class MongoDbEntityCopyTests {
+    @Autowired
+    lateinit var businessMongoDbRepository: BusinessMongoDbRepository
+
+    // 얕은 복사 테스트용 엔티티
+    private fun BusinessMongoDbEntity.shallowCopySameSet(): BusinessMongoDbEntity =
+        BusinessMongoDbEntity(
+            id = this.id,
+            createdDate = this.createdDate,
+            lastModifiedDate = this.lastModifiedDate,
+            name = this.name,
+            sigunguCode = this.sigunguCode,
+            zipCode = this.zipCode,
+            address = this.address,
+            addressDetail = this.addressDetail,
+            latitude = this.latitude,
+            longitude = this.longitude,
+            type = this.type,
+            item = this.item,
+            averageOrderAmount = this.averageOrderAmount,
+            seatCount = this.seatCount,
+            customerSegments = this.customerSegments // Set 인스턴스 참조(얕은 복사)
+        )
+
+    @Test
+    fun test() {
+        // given
+        val originalMongoDbEntity = BusinessMongoDbEntity(
+            name = "",
+            sigunguCode = "",
+            zipCode = "",
+            address = "",
+            addressDetail = null,
+            latitude = 0.0,
+            longitude = 0.0,
+            type = "",
+            item = "",
+            averageOrderAmount = 0.0,
+            seatCount = 10,
+            customerSegments = setOf(CustomerSegment.FAMILY)
+        )
+
+        val savedMongoDbEntity = businessMongoDbRepository.save(originalMongoDbEntity)
+
+        // when
+        val foundMongoDbEntity = businessMongoDbRepository.findById(savedMongoDbEntity.id)
+            .orElseThrow()
+
+        val copiedMongoDbEntity = foundMongoDbEntity.copy(
+            name = "테스트",
+            customerSegments = setOf(CustomerSegment.COUPLE),
+        )
+        val shallowCopiedMongoDbEntity = foundMongoDbEntity.shallowCopySameSet()
+
+        // 원본 Set 수정 시도
+        (foundMongoDbEntity.customerSegments as? MutableSet<CustomerSegment>)
+            ?.add(CustomerSegment.COUPLE)
+
+        // then
+        assertThat(copiedMongoDbEntity.id).isEqualTo(foundMongoDbEntity.id)
+        assertThat(copiedMongoDbEntity.name).isEqualTo("테스트")
+        assertThat(copiedMongoDbEntity.customerSegments).containsExactly(CustomerSegment.COUPLE)
+
+        // 원본에 COUPLE 추가해도 copy에는 영향 없음
+        assertThat(copiedMongoDbEntity.customerSegments).doesNotContain(CustomerSegment.FAMILY)
+
+        // then (얕은 복사 검증)
+        // shallow copy는 같은 Set 참조를 쓰므로 원본 수정이 반영됨
+        assertThat(shallowCopiedMongoDbEntity.customerSegments).contains(CustomerSegment.COUPLE)
+        assertThat(shallowCopiedMongoDbEntity.customerSegments).contains(CustomerSegment.FAMILY)
+    }
+}


### PR DESCRIPTION
# refactor: businessMongoDbEntity

## Note

추후 엔티티 수정을 고려했을 때 간편하게 사용할 수 있도록 copy() 메서드를 추가했습니다.