### PR TITLE
feat: 개발 환경에서 MongoDB 커맨드를 한눈에 볼 수 있도록 설정

### DIFF
--- a/src/main/kotlin/thatline/localup/common/configuration/MongoDbConfiguration.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/MongoDbConfiguration.kt
@@ -1,0 +1,32 @@
+package thatline.localup.common.configuration
+
+import com.mongodb.event.CommandFailedEvent
+import com.mongodb.event.CommandListener
+import com.mongodb.event.CommandStartedEvent
+import com.mongodb.event.CommandSucceededEvent
+import org.bson.json.JsonWriterSettings
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.mongo.MongoClientSettingsBuilderCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class MongoDbConfiguration {
+
+    @Bean
+    fun mongoClientSettingsBuilderCustomizer() = MongoClientSettingsBuilderCustomizer { builder ->
+        builder.addCommandListener(object : CommandListener {
+            private val log = LoggerFactory.getLogger("mongodb-query")
+            private val jsonWriterSettings = JsonWriterSettings.builder().indent(true).build()
+
+            override fun commandStarted(event: CommandStartedEvent) {
+                if (log.isDebugEnabled) {
+                    log.debug("\nMongoDB Query:\n${event.command.toJson(jsonWriterSettings)}")
+                }
+            }
+
+            override fun commandSucceeded(event: CommandSucceededEvent) {}
+            override fun commandFailed(event: CommandFailedEvent) {}
+        })
+    }
+}

--- a/src/main/kotlin/thatline/localup/common/configuration/MongoDbConfiguration.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/MongoDbConfiguration.kt
@@ -16,12 +16,12 @@ class MongoDbConfiguration {
     @Bean
     fun mongoClientSettingsBuilderCustomizer() = MongoClientSettingsBuilderCustomizer { builder ->
         builder.addCommandListener(object : CommandListener {
-            private val log = LoggerFactory.getLogger("mongodb-query")
+            private val log = LoggerFactory.getLogger("mongodb-command")
             private val jsonWriterSettings = JsonWriterSettings.builder().indent(true).build()
 
             override fun commandStarted(event: CommandStartedEvent) {
                 if (log.isDebugEnabled) {
-                    log.debug("\nMongoDB Query:\n${event.command.toJson(jsonWriterSettings)}")
+                    log.debug("\nMongoDB Command:\n${event.command.toJson(jsonWriterSettings)}")
                 }
             }
 

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -8,12 +8,7 @@ spring:
       password: root
 logging:
   level:
-    org:
-      springframework:
-        data:
-          mongodb:
-            core:
-              MongoTemplate: DEBUG
+    mongodb-query: DEBUG
 
 token:
   access-token:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -8,7 +8,7 @@ spring:
       password: root
 logging:
   level:
-    mongodb-query: DEBUG
+    mongodb-command: DEBUG
 
 token:
   access-token:


### PR DESCRIPTION
# feat: 개발 환경에서 MongoDB 커맨드를 한눈에 볼 수 있도록 설정

## Note

개발 환경에서 MongoTemplate 로그 레벨을 DEBUG로 설정해 쿼리를 확인했으나, 한 줄 출력으로 가독성이 떨어졌습니다. MongoDB Java Driver의 CommandListener를 등록하여 실행 커맨드를 줄바꿈/들여쓰기 형태로 볼 수 있도록 개선했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - MongoDB 명령을 디버그 레벨에서 보기 좋게 정렬된 JSON으로 로깅합니다. 문제 분석 시 쿼리 내용을 더 쉽게 파악할 수 있습니다.

- 작업
  - 로컬 프로필 로깅 설정을 업데이트하여 특정 클래스 기반 로거 대신 커스텀 로거 이름을 사용하도록 변경했습니다. 이제 mongodb-command 로거 레벨로 MongoDB 명령 로그 노출을 제어할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->