### PR TITLE
feat: MongoDB 비즈니스 메서드 커맨드 카운트 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/main/kotlin/thatline/localup/auth/service/AuthService.kt
+++ b/src/main/kotlin/thatline/localup/auth/service/AuthService.kt
@@ -3,11 +3,11 @@ package thatline.localup.auth.service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import thatline.localup.auth.dto.AuthToken
 import thatline.localup.auth.dto.UserDetails
 import thatline.localup.auth.exception.DuplicateEmailException
 import thatline.localup.auth.exception.InvalidCredentialsException
+import thatline.localup.common.annotation.CountMongoDbCommands
 import thatline.localup.common.constant.Role
 import thatline.localup.user.entity.UserMongoDbEntity
 import thatline.localup.user.repository.UserMongoDbRepository
@@ -19,6 +19,7 @@ class AuthService(
     private val userRepository: UserMongoDbRepository,
     private val userTokenRedisService: UserTokenRedisService,
 ) {
+    @CountMongoDbCommands
     fun signIn(email: String, password: String): AuthToken {
         val user = userRepository.findByEmail(email)
             ?: throw InvalidCredentialsException()
@@ -38,7 +39,7 @@ class AuthService(
         userTokenRedisService.deleteByAccessToken(accessToken)
     }
 
-    @Transactional
+    @CountMongoDbCommands
     fun signUp(email: String, password: String) {
         if (userRepository.existsByEmail(email)) {
             throw DuplicateEmailException()
@@ -56,6 +57,7 @@ class AuthService(
         userRepository.save(newUser)
     }
 
+    @CountMongoDbCommands
     fun findUserDetailsByAccessToken(accessToken: String): UserDetails? {
         val userId = userTokenRedisService.findUserIdByAccessToken(accessToken)
             ?: return null

--- a/src/main/kotlin/thatline/localup/common/annotation/CountMongoDbCommands.kt
+++ b/src/main/kotlin/thatline/localup/common/annotation/CountMongoDbCommands.kt
@@ -1,0 +1,5 @@
+package thatline.localup.common.annotation
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CountMongoDbCommands

--- a/src/main/kotlin/thatline/localup/common/aspect/MongoDbCommandCountAspect.kt
+++ b/src/main/kotlin/thatline/localup/common/aspect/MongoDbCommandCountAspect.kt
@@ -1,0 +1,41 @@
+package thatline.localup.common.aspect
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import thatline.localup.common.annotation.CountMongoDbCommands
+import thatline.localup.common.configuration.MongoDbCommandCounter
+
+@Aspect
+@Component
+class MongoDbCommandCountAspect {
+    companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java)
+    }
+
+    @Around("@annotation(countMongoDbCommands)")
+    fun countCommands(
+        joinPoint: ProceedingJoinPoint,
+        countMongoDbCommands: CountMongoDbCommands,
+    ): Any? {
+        MongoDbCommandCounter.reset()
+
+        return try {
+            val result = joinPoint.proceed()
+
+            if (logger.isDebugEnabled) {
+                logger.debug(
+                    "{} executed {} MongoDB commands",
+                    joinPoint.signature.toShortString(),
+                    MongoDbCommandCounter.get(),
+                )
+            }
+
+            result
+        } finally {
+            MongoDbCommandCounter.clear()
+        }
+    }
+}

--- a/src/main/kotlin/thatline/localup/common/aspect/MongoDbCommandCountAspect.kt
+++ b/src/main/kotlin/thatline/localup/common/aspect/MongoDbCommandCountAspect.kt
@@ -20,22 +20,18 @@ class MongoDbCommandCountAspect {
         joinPoint: ProceedingJoinPoint,
         countMongoDbCommands: CountMongoDbCommands,
     ): Any? {
-        MongoDbCommandCounter.reset()
-
+        MongoDbCommandCounter.begin()
         return try {
-            val result = joinPoint.proceed()
-
-            if (logger.isDebugEnabled) {
+            joinPoint.proceed()
+        } finally {
+            val endResult = MongoDbCommandCounter.end()
+            if (endResult.isOutermostExit && logger.isDebugEnabled) {
                 logger.debug(
                     "{} executed {} MongoDB commands",
                     joinPoint.signature.toShortString(),
-                    MongoDbCommandCounter.get(),
+                    endResult.totalCommandCount
                 )
             }
-
-            result
-        } finally {
-            MongoDbCommandCounter.clear()
         }
     }
 }

--- a/src/main/kotlin/thatline/localup/common/aspect/MongoDbCommandCountAspect.kt
+++ b/src/main/kotlin/thatline/localup/common/aspect/MongoDbCommandCountAspect.kt
@@ -20,16 +20,21 @@ class MongoDbCommandCountAspect {
         joinPoint: ProceedingJoinPoint,
         countMongoDbCommands: CountMongoDbCommands,
     ): Any? {
-        MongoDbCommandCounter.begin()
+        MongoDbCommandCounter.startScope()
+
         return try {
             joinPoint.proceed()
         } finally {
-            val endResult = MongoDbCommandCounter.end()
-            if (endResult.isOutermostExit && logger.isDebugEnabled) {
+            val result = MongoDbCommandCounter.finishScope()
+
+            if (logger.isDebugEnabled) {
+                val suffix = if (result.isRootScopeExit) " (total)" else ""
+
                 logger.debug(
-                    "{} executed {} MongoDB commands",
+                    "{} executed {} MongoDB commands{}",
                     joinPoint.signature.toShortString(),
-                    endResult.totalCommandCount
+                    result.commandCountInScope,
+                    suffix,
                 )
             }
         }

--- a/src/main/kotlin/thatline/localup/common/configuration/MongoDbCommandCounter.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/MongoDbCommandCounter.kt
@@ -1,19 +1,48 @@
 package thatline.localup.common.configuration
 
 object MongoDbCommandCounter {
-    private val commandCount = ThreadLocal.withInitial { 0 }
+    data class EndResult(
+        val isOutermostExit: Boolean,
+        val totalCommandCount: Int = 0,
+    )
+
+    private data class CounterState(var depth: Int = 0, var commandCount: Int = 0)
+
+    private val threadLocalState = ThreadLocal.withInitial { CounterState() }
+
+    fun begin() {
+        val state = threadLocalState.get()
+
+        state.depth += 1
+
+        if (state.depth == 1) {
+            state.commandCount = 0
+        }
+    }
+
+    fun end(): EndResult {
+        val state = threadLocalState.get()
+
+        state.depth -= 1
+
+        val isOutermostExit = (state.depth == 0)
+
+        return if (isOutermostExit) {
+            val totalCommands = state.commandCount
+
+            threadLocalState.remove()
+
+            EndResult(isOutermostExit = true, totalCommandCount = totalCommands)
+        } else {
+            EndResult(isOutermostExit = false, totalCommandCount = 0)
+        }
+    }
 
     fun increment() {
-        commandCount.set(commandCount.get() + 1)
-    }
+        val state = threadLocalState.get()
 
-    fun get(): Int = commandCount.get()
-
-    fun reset() {
-        commandCount.set(0)
-    }
-
-    fun clear() {
-        commandCount.remove()
+        if (state.depth > 0) {
+            state.commandCount += 1
+        }
     }
 }

--- a/src/main/kotlin/thatline/localup/common/configuration/MongoDbCommandCounter.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/MongoDbCommandCounter.kt
@@ -1,48 +1,50 @@
 package thatline.localup.common.configuration
 
 object MongoDbCommandCounter {
-    data class EndResult(
-        val isOutermostExit: Boolean,
-        val totalCommandCount: Int = 0,
-    )
+    private val commandStackTL = ThreadLocal.withInitial { ArrayDeque<Int>() }
 
-    private data class CounterState(var depth: Int = 0, var commandCount: Int = 0)
-
-    private val threadLocalState = ThreadLocal.withInitial { CounterState() }
-
-    fun begin() {
-        val state = threadLocalState.get()
-
-        state.depth += 1
-
-        if (state.depth == 1) {
-            state.commandCount = 0
-        }
-    }
-
-    fun end(): EndResult {
-        val state = threadLocalState.get()
-
-        state.depth -= 1
-
-        val isOutermostExit = (state.depth == 0)
-
-        return if (isOutermostExit) {
-            val totalCommands = state.commandCount
-
-            threadLocalState.remove()
-
-            EndResult(isOutermostExit = true, totalCommandCount = totalCommands)
-        } else {
-            EndResult(isOutermostExit = false, totalCommandCount = 0)
-        }
+    fun startScope() {
+        commandStackTL.get().addLast(0)
     }
 
     fun increment() {
-        val state = threadLocalState.get()
+        val stack = commandStackTL.get()
 
-        if (state.depth > 0) {
-            state.commandCount += 1
+        if (stack.isNotEmpty()) {
+            val current = stack.removeLast()
+
+            stack.addLast(current + 1)
         }
     }
+
+    fun finishScope(): CommandCountScopeResult {
+        val stack = commandStackTL.get()
+
+        if (stack.isEmpty()) {
+            return CommandCountScopeResult(isRootScopeExit = true, commandCountInScope = 0, remainingNestedDepth = 0)
+        }
+
+        val scopeCount = stack.removeLast()
+        val isRootScopeExit = stack.isEmpty()
+
+        if (!isRootScopeExit) {
+            val parent = stack.removeLast()
+
+            stack.addLast(parent + scopeCount)
+        } else {
+            commandStackTL.remove()
+        }
+
+        return CommandCountScopeResult(
+            isRootScopeExit = isRootScopeExit,
+            commandCountInScope = scopeCount,
+            remainingNestedDepth = stack.size
+        )
+    }
+
+    data class CommandCountScopeResult(
+        val isRootScopeExit: Boolean,
+        val commandCountInScope: Int = 0,
+        val remainingNestedDepth: Int = 0,
+    )
 }

--- a/src/main/kotlin/thatline/localup/common/configuration/MongoDbCommandCounter.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/MongoDbCommandCounter.kt
@@ -1,0 +1,19 @@
+package thatline.localup.common.configuration
+
+object MongoDbCommandCounter {
+    private val commandCount = ThreadLocal.withInitial { 0 }
+
+    fun increment() {
+        commandCount.set(commandCount.get() + 1)
+    }
+
+    fun get(): Int = commandCount.get()
+
+    fun reset() {
+        commandCount.set(0)
+    }
+
+    fun clear() {
+        commandCount.remove()
+    }
+}

--- a/src/main/kotlin/thatline/localup/common/configuration/MongoDbConfiguration.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/MongoDbConfiguration.kt
@@ -1,11 +1,5 @@
 package thatline.localup.common.configuration
 
-import com.mongodb.event.CommandFailedEvent
-import com.mongodb.event.CommandListener
-import com.mongodb.event.CommandStartedEvent
-import com.mongodb.event.CommandSucceededEvent
-import org.bson.json.JsonWriterSettings
-import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.mongo.MongoClientSettingsBuilderCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -15,18 +9,8 @@ class MongoDbConfiguration {
 
     @Bean
     fun mongoClientSettingsBuilderCustomizer() = MongoClientSettingsBuilderCustomizer { builder ->
-        builder.addCommandListener(object : CommandListener {
-            private val log = LoggerFactory.getLogger("mongodb-command")
-            private val jsonWriterSettings = JsonWriterSettings.builder().indent(true).build()
-
-            override fun commandStarted(event: CommandStartedEvent) {
-                if (log.isDebugEnabled) {
-                    log.debug("\nMongoDB Command:\n${event.command.toJson(jsonWriterSettings)}")
-                }
-            }
-
-            override fun commandSucceeded(event: CommandSucceededEvent) {}
-            override fun commandFailed(event: CommandFailedEvent) {}
-        })
+        builder
+            .addCommandListener(MongoDbCountingCommandListener())
+            .addCommandListener(MongoDbLoggingCommandListener())
     }
 }

--- a/src/main/kotlin/thatline/localup/common/configuration/MongoDbCountingCommandListener.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/MongoDbCountingCommandListener.kt
@@ -1,0 +1,10 @@
+package thatline.localup.common.configuration
+
+import com.mongodb.event.CommandListener
+import com.mongodb.event.CommandStartedEvent
+
+class MongoDbCountingCommandListener : CommandListener {
+    override fun commandStarted(event: CommandStartedEvent) {
+        MongoDbCommandCounter.increment()
+    }
+}

--- a/src/main/kotlin/thatline/localup/common/configuration/MongoDbLoggingCommandListener.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/MongoDbLoggingCommandListener.kt
@@ -1,0 +1,19 @@
+package thatline.localup.common.configuration
+
+import com.mongodb.event.CommandListener
+import com.mongodb.event.CommandStartedEvent
+import org.bson.json.JsonWriterSettings
+import org.slf4j.LoggerFactory
+
+class MongoDbLoggingCommandListener : CommandListener {
+    companion object {
+        private val logger = LoggerFactory.getLogger("mongodb-command")
+        private val jsonWriterSettings = JsonWriterSettings.builder().indent(true).build()
+    }
+
+    override fun commandStarted(event: CommandStartedEvent) {
+        if (logger.isDebugEnabled) {
+            logger.debug("\nMongoDB Command:\n${event.command.toJson(jsonWriterSettings)}")
+        }
+    }
+}

--- a/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
@@ -1,6 +1,7 @@
 package thatline.localup.dashboard.service
 
 import org.springframework.stereotype.Service
+import thatline.localup.common.annotation.CountMongoDbCommands
 import thatline.localup.dashboard.dto.DashboardOverview
 import thatline.localup.etcapi.service.WeatherService
 import thatline.localup.tourapi.service.TouristAttractionService
@@ -13,6 +14,7 @@ class DashboardFacade(
     private val weatherService: WeatherService,
 ) {
     // TODO-noah: rename sigunguCode -> legalDongSigunguCode
+    @CountMongoDbCommands
     fun getDashboardOverview(userId: String): DashboardOverview {
         val foundUserBusinessDto = userService.findBusiness(userId)
 

--- a/src/main/kotlin/thatline/localup/user/service/UserService.kt
+++ b/src/main/kotlin/thatline/localup/user/service/UserService.kt
@@ -1,6 +1,7 @@
 package thatline.localup.user.service
 
 import org.springframework.stereotype.Service
+import thatline.localup.common.annotation.CountMongoDbCommands
 import thatline.localup.user.dto.FindBusinessDto
 import thatline.localup.user.entity.BusinessMongoDbEntity
 import thatline.localup.user.entity.CustomerSegment
@@ -17,6 +18,7 @@ class UserService(
     private val userRepository: UserMongoDbRepository,
     private val businessRepository: BusinessMongoDbRepository,
 ) {
+    @CountMongoDbCommands
     fun findBusiness(
         userId: String,
     ): FindBusinessDto {
@@ -44,6 +46,7 @@ class UserService(
         )
     }
 
+    @CountMongoDbCommands
     fun registerBusiness(
         userId: String,
         businessName: String,
@@ -96,6 +99,7 @@ class UserService(
         userRepository.save(updatedUser)
     }
 
+    @CountMongoDbCommands
     fun updateBusiness(
         userId: String,
         businessName: String,

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -9,6 +9,11 @@ spring:
 logging:
   level:
     mongodb-command: DEBUG
+    thatline:
+      localup:
+        common:
+          aspect:
+            MongoDbCommandCountAspect: DEBUG
 
 token:
   access-token:


### PR DESCRIPTION
# feat: MongoDB 비즈니스 메서드 커맨드 카운트 기능 추가 

## Note

기존 비즈니스 로직에서 MongoDB 커맨드가 몇 개 실행되는지 파악하기 어려웠습니다. MongoDB의 CommandListener와 스프링 AOP를 활용해 @CountMongoDbCommands 어노테이션을 도입했습니다. 중첩 사용 시에는 각 단계별 로그와 함께 최종적으로 total 값이 출력되도록 개선했습니다. 다음은 예시입니다.

```
.c.a.MongoDbCommandCountAspect$Companion : UserService.findBusiness(..) executed 2 MongoDB commands
.c.a.MongoDbCommandCountAspect$Companion : UserService.findBusiness(..) executed 2 MongoDB commands
.c.a.MongoDbCommandCountAspect$Companion : UserService.findBusiness(..) executed 2 MongoDB commands
.c.a.MongoDbCommandCountAspect$Companion : DashboardFacade.getDashboardOverview(..) executed 6 MongoDB commands (total)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - MongoDB 명령 실행 횟수 측정 기능을 도입하고 주요 사용자 흐름에 계측을 적용했습니다.
  - MongoDB 명령 디버그 로깅을 전용 리스너로 분리해 보다 읽기 쉬운 출력(들여쓰기 포함)을 제공합니다.
- 작업
  - Spring Boot AOP 의존성을 추가했습니다.
  - 로컬 환경에서 MongoDB 관련 디버그 로깅과 명령 카운트 로깅을 활성화하도록 로그 레벨을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->