### PR TITLE
feat: Open API 한도 초과 시 예외 발생 로직 추가

### DIFF
--- a/src/main/kotlin/thatline/localup/common/annotation/ApiWindow.kt
+++ b/src/main/kotlin/thatline/localup/common/annotation/ApiWindow.kt
@@ -1,0 +1,24 @@
+package thatline.localup.common.annotation
+
+import thatline.localup.common.util.DateTimeUtil
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+enum class ApiWindow(
+    private val generateKey: () -> String,
+    val ttl: Long,
+) {
+    DAILY({
+        LocalDate.now().atStartOfDay().format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMddHHmmss)
+    }, 86400),
+
+    WEEKLY({
+        LocalDate.now().with(DayOfWeek.MONDAY).atStartOfDay().format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMddHHmmss)
+    }, 604800),
+
+    MONTHLY({
+        LocalDate.now().withDayOfMonth(1).atStartOfDay().format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMddHHmmss)
+    }, 2592000);
+
+    fun getKey(): String = generateKey()
+}

--- a/src/main/kotlin/thatline/localup/common/annotation/OpenApiQuota.kt
+++ b/src/main/kotlin/thatline/localup/common/annotation/OpenApiQuota.kt
@@ -1,0 +1,9 @@
+package thatline.localup.common.annotation
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class OpenApiQuota(
+    val name: String,
+    val limit: Long,
+    val apiWindow: ApiWindow,
+)

--- a/src/main/kotlin/thatline/localup/common/aspect/OpenApiQuotaAspect.kt
+++ b/src/main/kotlin/thatline/localup/common/aspect/OpenApiQuotaAspect.kt
@@ -3,7 +3,6 @@ package thatline.localup.common.aspect
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
-import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Component
 import thatline.localup.common.annotation.OpenApiQuota
@@ -15,10 +14,6 @@ import java.util.concurrent.TimeUnit
 class OpenApiQuotaAspect(
     private val redisTemplate: StringRedisTemplate,
 ) {
-    companion object {
-        private val logger = LoggerFactory.getLogger(this::class.java)
-    }
-
     @Around("@annotation(openApiQuota)")
     fun checkQuota(proceedingJoinPoint: ProceedingJoinPoint, openApiQuota: OpenApiQuota): Any? {
         val key = "openApi:${openApiQuota.name}:${openApiQuota.apiWindow.getKey()}"

--- a/src/main/kotlin/thatline/localup/common/aspect/OpenApiQuotaAspect.kt
+++ b/src/main/kotlin/thatline/localup/common/aspect/OpenApiQuotaAspect.kt
@@ -1,0 +1,42 @@
+package thatline.localup.common.aspect
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import thatline.localup.common.annotation.OpenApiQuota
+import thatline.localup.common.exception.OpenApiQuotaExceededException
+import java.util.concurrent.TimeUnit
+
+@Aspect
+@Component
+class OpenApiQuotaAspect(
+    private val redisTemplate: StringRedisTemplate,
+) {
+    companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java)
+    }
+
+    @Around("@annotation(openApiQuota)")
+    fun checkQuota(proceedingJoinPoint: ProceedingJoinPoint, openApiQuota: OpenApiQuota): Any? {
+        val key = "openApi:${openApiQuota.name}:${openApiQuota.apiWindow.getKey()}"
+
+        val currentCount = redisTemplate.opsForValue().increment(key) ?: 1L
+
+        if (currentCount == 1L) {
+            redisTemplate.expire(key, openApiQuota.apiWindow.ttl, TimeUnit.SECONDS)
+        }
+
+        if (currentCount > openApiQuota.limit) {
+            throw OpenApiQuotaExceededException(
+                name = openApiQuota.name,
+                limit = openApiQuota.limit,
+                currentCount = currentCount,
+            )
+        }
+
+        return proceedingJoinPoint.proceed()
+    }
+}

--- a/src/main/kotlin/thatline/localup/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/thatline/localup/common/exception/GlobalExceptionHandler.kt
@@ -21,4 +21,13 @@ class GlobalExceptionHandler {
             .status(HttpStatus.BAD_REQUEST)
             .body(BaseResponse.failure(message = errorMessage))
     }
+
+    @ExceptionHandler(OpenApiQuotaExceededException::class)
+    fun handleOpenApiQuotaExceededException(
+        exception: OpenApiQuotaExceededException,
+    ): ResponseEntity<BaseResponse<Unit>> {
+        return ResponseEntity
+            .status(HttpStatus.TOO_MANY_REQUESTS)
+            .body(BaseResponse.failure(message = exception.message))
+    }
 }

--- a/src/main/kotlin/thatline/localup/common/exception/OpenApiQuotaExceededException.kt
+++ b/src/main/kotlin/thatline/localup/common/exception/OpenApiQuotaExceededException.kt
@@ -1,0 +1,8 @@
+package thatline.localup.common.exception
+
+class OpenApiQuotaExceededException(
+    val name: String,
+    val limit: Long,
+    val currentCount: Long,
+    cause: Throwable? = null,
+) : BaseException("OPEN_API_QUOTA_EXCEEDED, name: $name, limit: $limit, currentCount: $currentCount", cause)

--- a/src/main/kotlin/thatline/localup/common/util/DateTimeUtil.kt
+++ b/src/main/kotlin/thatline/localup/common/util/DateTimeUtil.kt
@@ -8,10 +8,11 @@ import java.time.temporal.WeekFields
 import kotlin.math.min
 
 object DateTimeUtil {
-    val DATETIME_FORMATTER_yyyyMM: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMM")
-    val DATETIME_FORMATTER_yyyyMMdd: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
-    val DATETIME_FORMATTER_yyyyMMddHHmm: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmm")
-    val DATETIME_FORMATTER_HHmm: DateTimeFormatter = DateTimeFormatter.ofPattern("HHmm")
+    val DATETIME_FORMATTER_yyyyMM = DateTimeFormatter.ofPattern("yyyyMM")
+    val DATETIME_FORMATTER_yyyyMMdd = DateTimeFormatter.ofPattern("yyyyMMdd")
+    val DATETIME_FORMATTER_yyyyMMddHHmm = DateTimeFormatter.ofPattern("yyyyMMddHHmm")
+    val DATETIME_FORMATTER_yyyyMMddHHmmss = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+    val DATETIME_FORMATTER_HHmm = DateTimeFormatter.ofPattern("HHmm")
 
     // LocalDate 기준, 작년 같은 ISO 주차 범위 반환
     fun getLastYearSameIsoWeekRange(localDate: LocalDate = LocalDate.now()): Pair<LocalDate, LocalDate> {

--- a/src/main/kotlin/thatline/localup/etcapi/restclient/EtcApiRestClient.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/restclient/EtcApiRestClient.kt
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientException
 import org.springframework.web.util.UriComponentsBuilder
+import thatline.localup.common.annotation.ApiWindow
+import thatline.localup.common.annotation.OpenApiQuota
 import thatline.localup.common.property.EtcApiProperty
 import thatline.localup.etcapi.exception.ExternalEtcApiException
 import thatline.localup.etcapi.response.GetFcstVersionResponse
@@ -35,6 +37,7 @@ class EtcApiRestClient(
      *
      * @see <a href="https://www.data.go.kr/data/15084084/openapi.do">공공데이터포털 API 문서</a>
      */
+    @OpenApiQuota(name = "vilageFcstInfoService_2.0:getUltraSrtNcst", limit = 10000, ApiWindow.DAILY)
     fun getUltraSrtNcst(
         pageNo: Long,
         numOfRows: Long,
@@ -86,6 +89,7 @@ class EtcApiRestClient(
      *
      * @see <a href="https://www.data.go.kr/data/15084084/openapi.do">공공데이터포털 API 문서</a>
      */
+    @OpenApiQuota(name = "vilageFcstInfoService_2.0:getVilageFcst", limit = 10000, ApiWindow.DAILY)
     fun getVilageFcst(
         pageNo: Long,
         numOfRows: Long,
@@ -135,6 +139,7 @@ class EtcApiRestClient(
      *
      * @see <a href="https://www.data.go.kr/data/15084084/openapi.do">공공데이터포털 API 문서</a>
      */
+    @OpenApiQuota(name = "vilageFcstInfoService_2.0:getFcstVersion", limit = 10000, ApiWindow.DAILY)
     fun getFcstVersion(
         pageNo: Long,
         numOfRows: Long,

--- a/src/main/kotlin/thatline/localup/tourapi/restclient/TourApiRestClient.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/restclient/TourApiRestClient.kt
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientException
 import org.springframework.web.util.UriComponentsBuilder
+import thatline.localup.common.annotation.ApiWindow
+import thatline.localup.common.annotation.OpenApiQuota
 import thatline.localup.common.property.TourApiProperty
 import thatline.localup.common.util.queryParamIfNotNull
 import thatline.localup.tourapi.exception.TourApiException
@@ -31,6 +33,7 @@ class TourApiRestClient(
      *
      * @see <a href="https://www.data.go.kr/data/15101578/openapi.do">공공데이터포털 API 문서</a>
      */
+    @OpenApiQuota(name = "korService2:areaCode2", limit = 1000, ApiWindow.DAILY)
     // TODO-noah: 중복된 메서드 이름, 이름 정의 재설정 필요
     fun areaCode2(
         pageNo: Long,
@@ -72,6 +75,7 @@ class TourApiRestClient(
      * @see <a href="https://www.data.go.kr/data/15101578/openapi.do">공공데이터포털 API 문서</a>
      */
     // TODO-noah: 중복된 메서드 이름, 이름 정의 재설정 필요
+    @OpenApiQuota(name = "korService2:ldongCode2", limit = 1000, ApiWindow.DAILY)
     fun ldongCode2(
         pageNo: Long,
         numOfRows: Long,
@@ -115,6 +119,7 @@ class TourApiRestClient(
      *
      * @see <a href="https://www.data.go.kr/data/15101578/openapi.do">공공데이터포털 API 문서</a>
      */
+    @OpenApiQuota(name = "korService2:areaBasedList2", limit = 1000, ApiWindow.DAILY)
     fun korService2AreaBasedList2(
         pageNo: Long? = null,
         numOfRows: Long? = null,
@@ -173,6 +178,7 @@ class TourApiRestClient(
      *
      * @see <a href="https://www.data.go.kr/data/15101578/openapi.do">공공데이터포털 API 문서</a>
      */
+    @OpenApiQuota(name = "korService2:searchFestival2", limit = 1000, ApiWindow.DAILY)
     fun korService2SearchFestival2(
         pageNo: Long? = null,
         numOfRows: Long? = null,
@@ -227,6 +233,7 @@ class TourApiRestClient(
      *
      * @see <a href="https://www.data.go.kr/data/15101578/openapi.do">공공데이터포털 API 문서</a>
      */
+    @OpenApiQuota(name = "korService2:detailIntro215", limit = 1000, ApiWindow.DAILY)
     fun korService2DetailIntro215(
         contentId: String,
         contentTypeId: String = "15",
@@ -277,6 +284,7 @@ class TourApiRestClient(
      *
      * @see <a href="https://www.data.go.kr/data/15128560/openapi.do">공공데이터포털 API 문서</a>
      */
+    @OpenApiQuota(name = "tarRlteTarService1:areaBasedList", limit = 1000, ApiWindow.DAILY) //
     // TODO-noah: 중복된 메서드 이름, 이름 정의 재설정 필요
     fun areaBasedList(
         pageNo: Long,
@@ -320,6 +328,7 @@ class TourApiRestClient(
      *
      * @see <a href="https://www.data.go.kr/data/15128559/openapi.do">공공데이터포털 API 문서</a>
      */
+    @OpenApiQuota(name = "locgoHubTarService1:areaBasedList2", limit = 1000, ApiWindow.DAILY)
     // TODO-noah: 중복된 메서드 이름, 이름 정의 재설정 필요
     fun areaBasedList2(
         pageNo: Long,
@@ -363,6 +372,7 @@ class TourApiRestClient(
      *
      * @see <a href="https://www.data.go.kr/data/15128555/openapi.do">공공데이터포털 API 문서</a>
      */
+    @OpenApiQuota(name = "tatsCnctrRateService:tatsCnctrRatedList", limit = 1000, ApiWindow.DAILY)
     // TODO-noah: 중복된 메서드 이름, 이름 정의 재설정 필요
     fun tatsCnctrRatedList(
         pageNo: Long,
@@ -405,6 +415,7 @@ class TourApiRestClient(
      *
      * @see <a href="https://www.data.go.kr/data/15101972/openapi.do">공공데이터포털 API 문서</a>
      */
+    @OpenApiQuota(name = "dataLabService:metcoRegnVisitrDDList", limit = 1000, ApiWindow.DAILY)
     // TODO-noah: 중복된 메서드 이름, 이름 정의 재설정 필요
     fun metcoRegnVisitrDDList(
         pageNo: Long,
@@ -443,6 +454,7 @@ class TourApiRestClient(
      *
      * @see <a href="https://www.data.go.kr/data/15101972/openapi.do">공공데이터포털 API 문서</a>
      */
+    @OpenApiQuota(name = "dataLabService:locgoRegnVisitrDDList", limit = 1000, ApiWindow.DAILY)
     // TODO-noah: 중복된 메서드 이름, 이름 정의 재설정 필요
     fun locgoRegnVisitrDDList(
         pageNo: Long,


### PR DESCRIPTION
# feat: Open API 한도 초과 시 예외 발생 로직 추가

## Note

Open API마다 시간/일/주/월 단위로 서로 다른 제한 주기와 허용량이 존재합니다. 본 로직은 Redis INCR 연산과 AOP를 활용하여 구현하였으며, 이를 통해 사전에 예외를 발생시켜 불필요한 호출을 방지할 수 있습니다. 또한 추후 모니터링 및 운영 관점에서도 유용하게 활용하실 수 있다고 생각합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Open API 호출에 윈도우(일/주/월) 기반 쿼터 제한을 도입했습니다. 한도를 초과하면 HTTP 429(Too Many Requests)와 명확한 안내 메시지를 반환합니다.
  - 기상·관광 관련 주요 엔드포인트에 일일 호출 한도를 적용하여 트래픽 급증 시 서비스 안정성을 강화했습니다. 한도는 엔드포인트별로 개별 관리됩니다.
  - 동일 윈도우 내 반복 호출 시 한도 도달 전에는 정상 응답, 도달 후에는 차단되며, 다음 윈도우 시작 시 자동으로 호출이 재개됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->