### PR TITLE
fix: 대시보드, 방문자 수 관련 API 개선

### DIFF
--- a/src/main/kotlin/thatline/localup/common/configuration/CacheConfiguration.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/CacheConfiguration.kt
@@ -16,10 +16,11 @@ import thatline.localup.common.constant.CacheObjectName
 import thatline.localup.common.util.DateTimeUtil
 import thatline.localup.etcapi.dto.ShortTermForecastInformation
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
-import thatline.localup.tourapi.dto.LastYearSameWeekVisitorStatisticsInformation
 import thatline.localup.tourapi.dto.OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation
 import thatline.localup.tourapi.dto.SigunguMainEventInformation
+import thatline.localup.tourapi.dto.VisitorStatisticsInformation
 import java.time.Duration
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.temporal.ChronoUnit
@@ -48,6 +49,20 @@ class CacheConfiguration(
             )
             .entryTtl(Duration.ofHours(3))
 
+        // 대시보드, 시군구 방문자 수 통계 정보 캐시 설정
+        val visitorStatisticsInformationCacheConfiguration = defaultCacheConfiguration
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    Jackson2JsonRedisSerializer(
+                        objectMapper,
+                        VisitorStatisticsInformation::class.java
+                    )
+                )
+            )
+            .entryTtl(Duration.ofDays(7))
+
+        // 개선 전
+
         // 대시보드, 지난 달 관광지 랭킹 정보 캐시 설정
         val lastMonthlyTouristAttractionRankingInformationCacheConfiguration = defaultCacheConfiguration
             .serializeValuesWith(
@@ -59,18 +74,6 @@ class CacheConfiguration(
                 )
             )
             .entryTtl(Duration.ofDays(31))
-
-        // 대시보드, 작년 같은 주, 지역 방문자 수 통계 정보 캐시 설정
-        val lastYearSameWeekVisitorStatisticsInformationCacheConfiguration = defaultCacheConfiguration
-            .serializeValuesWith(
-                RedisSerializationContext.SerializationPair.fromSerializer(
-                    Jackson2JsonRedisSerializer(
-                        objectMapper,
-                        LastYearSameWeekVisitorStatisticsInformation::class.java
-                    )
-                )
-            )
-            .entryTtl(Duration.ofDays(7))
 
         // 대시보드, 시군구 메인 이벤트 정보 캐시 설정
         val sigunguMainEventInformationCacheConfiguration = defaultCacheConfiguration
@@ -98,10 +101,9 @@ class CacheConfiguration(
 
         val cacheConfigurations = mapOf(
             CacheObjectName.SHORT_TERM_FORECAST_INFORMATION to shortTermForecastsInformationCacheConfiguration,
+            CacheObjectName.VISITOR_STATISTICS_INFORMATION to visitorStatisticsInformationCacheConfiguration,
 
             CacheObjectName.LAST_MONTHLY_TOURIST_ATTRACTION_RANKING_INFORMATION to lastMonthlyTouristAttractionRankingInformationCacheConfiguration,
-            CacheObjectName.LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS_INFORMATION to lastYearSameWeekVisitorStatisticsInformationCacheConfiguration,
-
             CacheObjectName.SIGUNGU_MAIN_EVENT_INFORMATION to sigunguMainEventInformationCacheConfiguration,
             CacheObjectName.ONGOING_OR_UPCOMING_SIGUNGU_EVENTS_FROM_TODAY_TO_MONTH_END_INFORMATION to ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformationCacheConfiguration,
             // 다른 캐시 설정 추가
@@ -126,6 +128,19 @@ class CacheConfiguration(
     }
 
     @Bean
+    fun visitorStatisticsInformationKeyGenerator(): KeyGenerator {
+        return KeyGenerator { _, _, params ->
+            val sigunguCode = params[0] as String
+            val startDate = (params[1] as LocalDate).format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
+            val endDate = (params[2] as LocalDate).format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
+
+            "$sigunguCode-$startDate-$endDate"
+        }
+    }
+
+    // 개선 전
+
+    @Bean
     fun lastMonthlyTouristAttractionRankingKeyGenerator(): KeyGenerator {
         return KeyGenerator { _, _, params ->
             val sigunguCode = params[1] as String
@@ -133,20 +148,6 @@ class CacheConfiguration(
             val savedDateTime = YearMonth.now().format(DateTimeUtil.DATETIME_FORMATTER_yyyyMM)
 
             "$sigunguCode-$savedDateTime"
-        }
-    }
-
-    @Bean
-    fun lastYearSameWeekVisitorStatisticsKeyGenerator(): KeyGenerator {
-        return KeyGenerator { _, _, params ->
-            val sigunguCode = params[0] as String
-
-            val (startDate, endDate) = DateTimeUtil.getLastYearSameIsoWeekRange()
-
-            val startDateFormat = startDate.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
-            val endDateFormat = endDate.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
-
-            "$sigunguCode-$startDateFormat-$endDateFormat"
         }
     }
 

--- a/src/main/kotlin/thatline/localup/common/configuration/CacheConfiguration.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/CacheConfiguration.kt
@@ -14,7 +14,7 @@ import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
 import thatline.localup.common.constant.CacheObjectName
 import thatline.localup.common.util.DateTimeUtil
-import thatline.localup.etcapi.dto.WeatherInformation
+import thatline.localup.etcapi.dto.ShortTermForecastInformation
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
 import thatline.localup.tourapi.dto.LastYearSameWeekVisitorStatisticsInformation
 import thatline.localup.tourapi.dto.OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation
@@ -35,6 +35,18 @@ class CacheConfiguration(
         val defaultCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
             .disableCachingNullValues()
+
+        // 대시보드, 시군구 단기 예보 정보 캐시 설정
+        val shortTermForecastsInformationCacheConfiguration = defaultCacheConfiguration
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    Jackson2JsonRedisSerializer(
+                        objectMapper,
+                        ShortTermForecastInformation::class.java
+                    )
+                )
+            )
+            .entryTtl(Duration.ofHours(3))
 
         // 대시보드, 지난 달 관광지 랭킹 정보 캐시 설정
         val lastMonthlyTouristAttractionRankingInformationCacheConfiguration = defaultCacheConfiguration
@@ -84,22 +96,12 @@ class CacheConfiguration(
             )
             .entryTtl(Duration.ofDays(1))
 
-        // 대시보드, 시군구 날씨 정보 캐시 설정
-        val weatherInformationCacheConfiguration = defaultCacheConfiguration
-            .serializeValuesWith(
-                RedisSerializationContext.SerializationPair.fromSerializer(
-                    Jackson2JsonRedisSerializer(
-                        objectMapper,
-                        WeatherInformation::class.java
-                    )
-                )
-            )
-            .entryTtl(Duration.ofHours(3))
-
         val cacheConfigurations = mapOf(
+            CacheObjectName.SHORT_TERM_FORECAST_INFORMATION to shortTermForecastsInformationCacheConfiguration,
+
             CacheObjectName.LAST_MONTHLY_TOURIST_ATTRACTION_RANKING_INFORMATION to lastMonthlyTouristAttractionRankingInformationCacheConfiguration,
             CacheObjectName.LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS_INFORMATION to lastYearSameWeekVisitorStatisticsInformationCacheConfiguration,
-            CacheObjectName.WEATHER_INFORMATION to weatherInformationCacheConfiguration,
+
             CacheObjectName.SIGUNGU_MAIN_EVENT_INFORMATION to sigunguMainEventInformationCacheConfiguration,
             CacheObjectName.ONGOING_OR_UPCOMING_SIGUNGU_EVENTS_FROM_TODAY_TO_MONTH_END_INFORMATION to ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformationCacheConfiguration,
             // 다른 캐시 설정 추가
@@ -109,6 +111,18 @@ class CacheConfiguration(
             .cacheDefaults(defaultCacheConfiguration)
             .withInitialCacheConfigurations(cacheConfigurations)
             .build()
+    }
+
+    @Bean
+    fun shortTermForecastInformationKeyGenerator(): KeyGenerator {
+        return KeyGenerator { _, _, params ->
+            val sigunguCode = params[0] as String
+            val savedDateTime = (params[1] as LocalDateTime)
+                .truncatedTo(ChronoUnit.HOURS)
+                .withHour((params[1] as LocalDateTime).hour / 3 * 3)
+
+            "$sigunguCode-${savedDateTime.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMddHHmm)}"
+        }
     }
 
     @Bean
@@ -155,21 +169,6 @@ class CacheConfiguration(
             val sigunguCode = params[0] as String
 
             val savedDateTime = LocalDateTime.now().format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
-
-            "$sigunguCode-$savedDateTime"
-        }
-    }
-
-    @Bean
-    fun weatherInformationKeyGenerator(): KeyGenerator {
-        return KeyGenerator { _, _, params ->
-            val sigunguCode = params[0] as String
-
-            val now = LocalDateTime.now()
-                .truncatedTo(ChronoUnit.HOURS)
-
-            val savedDateTime = now.withHour((now.hour / 3) * 3)
-                .format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMddHHmm)
 
             "$sigunguCode-$savedDateTime"
         }

--- a/src/main/kotlin/thatline/localup/common/configuration/SecurityConfiguration.kt
+++ b/src/main/kotlin/thatline/localup/common/configuration/SecurityConfiguration.kt
@@ -49,7 +49,7 @@ class SecurityConfiguration(
                     .requestMatchers("/api/auth/**").permitAll()
                     .requestMatchers("/api/tour-api/**").permitAll()
                     .requestMatchers("/api/health").permitAll()
-                    .requestMatchers("/api/dashboard/test").permitAll()
+                    .requestMatchers("/api/dashboard/test/**").permitAll()
                     .anyRequest().authenticated()
             }
             .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter::class.java)

--- a/src/main/kotlin/thatline/localup/common/constant/CacheKeyGeneratorName.kt
+++ b/src/main/kotlin/thatline/localup/common/constant/CacheKeyGeneratorName.kt
@@ -1,10 +1,12 @@
 package thatline.localup.common.constant
 
 object CacheKeyGeneratorName {
+    const val SHORT_TERM_FORECAST_INFORMATION = "shortTermForecastInformationKeyGenerator"
+
+    // TODO-noah: 하나씩 수정
     const val LAST_MONTHLY_TOURIST_ATTRACTION_RANKING = "lastMonthlyTouristAttractionRankingKeyGenerator"
     const val LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS = "lastYearSameWeekVisitorStatisticsKeyGenerator"
     const val SIGUNGU_MAIN_EVENT = "sigunguMainEventKeyGenerator"
     const val ONGOING_OR_UPCOMING_SIGUNGU_EVENTS_FROM_TODAY_TO_MONTH_END =
         "ongoingOrUpComingSigunguEventsFromTodayToMonthEndKeyGenerator"
-    const val WEATHER_INFORMATION = "weatherInformationKeyGenerator"
 }

--- a/src/main/kotlin/thatline/localup/common/constant/CacheKeyGeneratorName.kt
+++ b/src/main/kotlin/thatline/localup/common/constant/CacheKeyGeneratorName.kt
@@ -2,10 +2,10 @@ package thatline.localup.common.constant
 
 object CacheKeyGeneratorName {
     const val SHORT_TERM_FORECAST_INFORMATION = "shortTermForecastInformationKeyGenerator"
+    const val VISITOR_STATISTICS_INFORMATION = "visitorStatisticsInformationKeyGenerator"
 
     // TODO-noah: 하나씩 수정
     const val LAST_MONTHLY_TOURIST_ATTRACTION_RANKING = "lastMonthlyTouristAttractionRankingKeyGenerator"
-    const val LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS = "lastYearSameWeekVisitorStatisticsKeyGenerator"
     const val SIGUNGU_MAIN_EVENT = "sigunguMainEventKeyGenerator"
     const val ONGOING_OR_UPCOMING_SIGUNGU_EVENTS_FROM_TODAY_TO_MONTH_END =
         "ongoingOrUpComingSigunguEventsFromTodayToMonthEndKeyGenerator"

--- a/src/main/kotlin/thatline/localup/common/constant/CacheObjectName.kt
+++ b/src/main/kotlin/thatline/localup/common/constant/CacheObjectName.kt
@@ -1,10 +1,12 @@
 package thatline.localup.common.constant
 
 object CacheObjectName {
+    const val SHORT_TERM_FORECAST_INFORMATION = "ShortTermForecastInformation"
+
+    // TODO-noah: 하나씩 수정
     const val LAST_MONTHLY_TOURIST_ATTRACTION_RANKING_INFORMATION = "lastMonthlyTouristAttractionRankingInformation"
     const val LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS_INFORMATION = "lastYearSameWeekVisitorStatisticsInformation"
     const val SIGUNGU_MAIN_EVENT_INFORMATION = "sigunguMainEventInformation"
     const val ONGOING_OR_UPCOMING_SIGUNGU_EVENTS_FROM_TODAY_TO_MONTH_END_INFORMATION =
         "ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation"
-    const val WEATHER_INFORMATION = "weatherInformation"
 }

--- a/src/main/kotlin/thatline/localup/common/constant/CacheObjectName.kt
+++ b/src/main/kotlin/thatline/localup/common/constant/CacheObjectName.kt
@@ -2,10 +2,10 @@ package thatline.localup.common.constant
 
 object CacheObjectName {
     const val SHORT_TERM_FORECAST_INFORMATION = "ShortTermForecastInformation"
+    const val VISITOR_STATISTICS_INFORMATION = "VisitorStatisticsInformation"
 
     // TODO-noah: 하나씩 수정
     const val LAST_MONTHLY_TOURIST_ATTRACTION_RANKING_INFORMATION = "lastMonthlyTouristAttractionRankingInformation"
-    const val LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS_INFORMATION = "lastYearSameWeekVisitorStatisticsInformation"
     const val SIGUNGU_MAIN_EVENT_INFORMATION = "sigunguMainEventInformation"
     const val ONGOING_OR_UPCOMING_SIGUNGU_EVENTS_FROM_TODAY_TO_MONTH_END_INFORMATION =
         "ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation"

--- a/src/main/kotlin/thatline/localup/dashboard/controller/DashboardController.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/controller/DashboardController.kt
@@ -1,5 +1,6 @@
 package thatline.localup.dashboard.controller
 
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -8,8 +9,10 @@ import org.springframework.web.bind.annotation.RestController
 import thatline.localup.common.annotation.RequireUser
 import thatline.localup.common.response.BaseResponse
 import thatline.localup.dashboard.dto.DashboardOverview
+import thatline.localup.dashboard.request.FindVisitorStatisticsRequest
 import thatline.localup.dashboard.service.DashboardFacade
 import thatline.localup.etcapi.dto.ShortTermForecastInformation
+import thatline.localup.tourapi.dto.VisitorStatisticsInformation
 
 @RestController
 @RequestMapping("/api/dashboard")
@@ -36,6 +39,20 @@ class DashboardController(
         return ResponseEntity.ok(BaseResponse.success(data = shortTermForecastInformation))
     }
 
+    @GetMapping("/visitor-statistics")
+    fun findVisitorStatistics(
+        @AuthenticationPrincipal userId: String,
+        @Valid request: FindVisitorStatisticsRequest,
+    ): ResponseEntity<BaseResponse<VisitorStatisticsInformation>> {
+        val visitorStatisticsInformation = dashboardFacade.findVisitorStatistics(
+            userId = userId,
+            startDate = request.startDate,
+            endDate = request.endDate,
+        )
+
+        return ResponseEntity.ok(BaseResponse.success(data = visitorStatisticsInformation))
+    }
+
     // TODO-noah: 삭제, 아직 인증이 완료되지 않아 사용하는 코드입니다.
     @GetMapping("/test")
     fun getDashboardInformation(): ResponseEntity<BaseResponse<DashboardOverview>> {
@@ -51,5 +68,19 @@ class DashboardController(
         val shortTermForecastInformation = dashboardFacade.findShortTermForecast("689eb417e295ca9144b875a0")
 
         return ResponseEntity.ok(BaseResponse.success(data = shortTermForecastInformation))
+    }
+
+    // TODO-noah: 삭제, 아직 인증이 완료되지 않아 사용하는 코드입니다.
+    @GetMapping("/test/visitor-statistics")
+    fun findVisitorStatisticsTest(
+        @Valid request: FindVisitorStatisticsRequest,
+    ): ResponseEntity<BaseResponse<VisitorStatisticsInformation>> {
+        val visitorStatisticsInformation = dashboardFacade.findVisitorStatistics(
+            userId = "689eb417e295ca9144b875a0",
+            startDate = request.startDate,
+            endDate = request.endDate,
+        )
+
+        return ResponseEntity.ok(BaseResponse.success(data = visitorStatisticsInformation))
     }
 }

--- a/src/main/kotlin/thatline/localup/dashboard/controller/DashboardController.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/controller/DashboardController.kt
@@ -9,6 +9,7 @@ import thatline.localup.common.annotation.RequireUser
 import thatline.localup.common.response.BaseResponse
 import thatline.localup.dashboard.dto.DashboardOverview
 import thatline.localup.dashboard.service.DashboardFacade
+import thatline.localup.etcapi.dto.ShortTermForecastInformation
 
 @RestController
 @RequestMapping("/api/dashboard")
@@ -25,6 +26,16 @@ class DashboardController(
         return ResponseEntity.ok(BaseResponse.success(data = dashboardOverview))
     }
 
+    @GetMapping("/short-term-forecast")
+    @RequireUser
+    fun findShortTermForecast(
+        @AuthenticationPrincipal userId: String,
+    ): ResponseEntity<BaseResponse<ShortTermForecastInformation>> {
+        val shortTermForecastInformation = dashboardFacade.findShortTermForecast(userId)
+
+        return ResponseEntity.ok(BaseResponse.success(data = shortTermForecastInformation))
+    }
+
     // TODO-noah: 삭제, 아직 인증이 완료되지 않아 사용하는 코드입니다.
     @GetMapping("/test")
     fun getDashboardInformation(): ResponseEntity<BaseResponse<DashboardOverview>> {
@@ -32,5 +43,13 @@ class DashboardController(
         val dashboardOverview = dashboardFacade.getDashboardOverview("689eb417e295ca9144b875a0")
 
         return ResponseEntity.ok(BaseResponse.success(data = dashboardOverview))
+    }
+
+    // TODO-noah: 삭제, 아직 인증이 완료되지 않아 사용하는 코드입니다.
+    @GetMapping("/test/short-term-forecast")
+    fun findShortTermForecastTest(): ResponseEntity<BaseResponse<ShortTermForecastInformation>> {
+        val shortTermForecastInformation = dashboardFacade.findShortTermForecast("689eb417e295ca9144b875a0")
+
+        return ResponseEntity.ok(BaseResponse.success(data = shortTermForecastInformation))
     }
 }

--- a/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
@@ -1,6 +1,6 @@
 package thatline.localup.dashboard.dto
 
-import thatline.localup.etcapi.dto.ShortTermForecast
+import thatline.localup.etcapi.dto.ShortTermForecastInformation
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
 import thatline.localup.tourapi.dto.LastYearSameWeekVisitorStatisticsInformation
 import thatline.localup.tourapi.dto.OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation
@@ -11,5 +11,6 @@ data class DashboardOverview(
     val lastYearSameWeekVisitorStatisticsInformation: LastYearSameWeekVisitorStatisticsInformation,
     val sigunguMainEventInformation: SigunguMainEventInformation,
     val ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation: OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation,
-    val weatherInformation: List<ShortTermForecast>,
+    // TODO: 분리
+    val weatherInformation: ShortTermForecastInformation,
 )

--- a/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
@@ -1,6 +1,5 @@
 package thatline.localup.dashboard.dto
 
-import thatline.localup.etcapi.dto.ShortTermForecastInformation
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
 import thatline.localup.tourapi.dto.LastYearSameWeekVisitorStatisticsInformation
 import thatline.localup.tourapi.dto.OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation
@@ -11,6 +10,4 @@ data class DashboardOverview(
     val lastYearSameWeekVisitorStatisticsInformation: LastYearSameWeekVisitorStatisticsInformation,
     val sigunguMainEventInformation: SigunguMainEventInformation,
     val ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation: OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation,
-    // TODO: 분리
-    val weatherInformation: ShortTermForecastInformation,
 )

--- a/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
@@ -1,13 +1,11 @@
 package thatline.localup.dashboard.dto
 
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
-import thatline.localup.tourapi.dto.LastYearSameWeekVisitorStatisticsInformation
 import thatline.localup.tourapi.dto.OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation
 import thatline.localup.tourapi.dto.SigunguMainEventInformation
 
 data class DashboardOverview(
     val lastMonthlyTouristAttractionRankingInformation: LastMonthlyTouristAttractionRankingInformation,
-    val lastYearSameWeekVisitorStatisticsInformation: LastYearSameWeekVisitorStatisticsInformation,
     val sigunguMainEventInformation: SigunguMainEventInformation,
     val ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation: OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation,
 )

--- a/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
@@ -1,15 +1,15 @@
 package thatline.localup.dashboard.dto
 
-import thatline.localup.etcapi.dto.WeatherInformation
+import thatline.localup.etcapi.service.ShortTermForecast
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
 import thatline.localup.tourapi.dto.LastYearSameWeekVisitorStatisticsInformation
-import thatline.localup.tourapi.dto.SigunguMainEventInformation
 import thatline.localup.tourapi.dto.OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation
+import thatline.localup.tourapi.dto.SigunguMainEventInformation
 
 data class DashboardOverview(
     val lastMonthlyTouristAttractionRankingInformation: LastMonthlyTouristAttractionRankingInformation,
     val lastYearSameWeekVisitorStatisticsInformation: LastYearSameWeekVisitorStatisticsInformation,
     val sigunguMainEventInformation: SigunguMainEventInformation,
     val ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation: OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation,
-    val weatherInformation: WeatherInformation,
+    val weatherInformation: List<ShortTermForecast>,
 )

--- a/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/dto/DashboardOverview.kt
@@ -1,6 +1,6 @@
 package thatline.localup.dashboard.dto
 
-import thatline.localup.etcapi.service.ShortTermForecast
+import thatline.localup.etcapi.dto.ShortTermForecast
 import thatline.localup.tourapi.dto.LastMonthlyTouristAttractionRankingInformation
 import thatline.localup.tourapi.dto.LastYearSameWeekVisitorStatisticsInformation
 import thatline.localup.tourapi.dto.OngoingOrUpComingSigunguEventsFromTodayToMonthEndInformation

--- a/src/main/kotlin/thatline/localup/dashboard/request/FindVisitorStatisticsRequest.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/request/FindVisitorStatisticsRequest.kt
@@ -1,0 +1,27 @@
+package thatline.localup.dashboard.request
+
+import jakarta.validation.constraints.AssertTrue
+import jakarta.validation.constraints.NotNull
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDate
+
+data class FindVisitorStatisticsRequest(
+    @field:NotNull
+    @field:DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    val startDate: LocalDate,
+
+    @field:NotNull
+    @field:DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    val endDate: LocalDate,
+) {
+//    TODO-noah: 범위 유호성 검사 필요
+//    @AssertTrue
+//    fun isYearInRange(): Boolean {
+//        return startDate.year in 2018..2024 && endDate.year in 2018..2024
+//    }
+//
+//    @AssertTrue
+//    fun isStartNotBeforeEnd(): Boolean {
+//        return !startDate.isBefore(endDate)
+//    }
+}

--- a/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
@@ -39,7 +39,7 @@ class DashboardFacade(
                 sigunguCode = foundUserBusinessDto.sigunguCode,
             )
 
-        val weatherInformation = weatherService.getThreeDayWeatherSummaries(
+        val weatherInformation = weatherService.findShortTermForecast(
             sigunguCode = foundUserBusinessDto.sigunguCode
         )
 

--- a/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
@@ -3,6 +3,7 @@ package thatline.localup.dashboard.service
 import org.springframework.stereotype.Service
 import thatline.localup.common.annotation.CountMongoDbCommands
 import thatline.localup.dashboard.dto.DashboardOverview
+import thatline.localup.etcapi.dto.ShortTermForecastInformation
 import thatline.localup.etcapi.service.ForecastService
 import thatline.localup.tourapi.service.TouristAttractionService
 import thatline.localup.user.service.UserService
@@ -39,16 +40,22 @@ class DashboardFacade(
                 sigunguCode = foundUserBusinessDto.sigunguCode,
             )
 
-        val weatherInformation = forecastService.findShortTermForecast(
-            sigunguCode = foundUserBusinessDto.sigunguCode
-        )
-
         return DashboardOverview(
             lastMonthlyTouristAttractionRankingInformation = lastMonthlyTouristAttractionRankingInformation,
             lastYearSameWeekVisitorStatisticsInformation = lastYearSameWeekVisitorStatisticsInformation,
             sigunguMainEventInformation = sigunguMainEventInformation,
             ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation = ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation,
-            weatherInformation = weatherInformation,
         )
+    }
+
+    @CountMongoDbCommands
+    fun findShortTermForecast(userId: String): ShortTermForecastInformation {
+        val foundUserBusinessDto = userService.findBusiness(userId)
+
+        val shortTermForecastInformation = forecastService.findShortTermForecast(
+            sigunguCode = foundUserBusinessDto.sigunguCode
+        )
+
+        return shortTermForecastInformation
     }
 }

--- a/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
@@ -5,8 +5,10 @@ import thatline.localup.common.annotation.CountMongoDbCommands
 import thatline.localup.dashboard.dto.DashboardOverview
 import thatline.localup.etcapi.dto.ShortTermForecastInformation
 import thatline.localup.etcapi.service.ForecastService
+import thatline.localup.tourapi.dto.VisitorStatisticsInformation
 import thatline.localup.tourapi.service.TouristAttractionService
 import thatline.localup.user.service.UserService
+import java.time.LocalDate
 
 @Service
 class DashboardFacade(
@@ -24,11 +26,6 @@ class DashboardFacade(
                 sigunguCode = foundUserBusinessDto.sigunguCode
             )
 
-        val lastYearSameWeekVisitorStatisticsInformation =
-            touristAttractionService.findLastYearSameWeekVisitorStatistics(
-                sigunguCode = foundUserBusinessDto.sigunguCode
-            )
-
         val sigunguMainEventInformation = touristAttractionService.findSigunguMainEvent(
             sigunguCode = foundUserBusinessDto.sigunguCode,
             latitude = foundUserBusinessDto.latitude,
@@ -42,7 +39,6 @@ class DashboardFacade(
 
         return DashboardOverview(
             lastMonthlyTouristAttractionRankingInformation = lastMonthlyTouristAttractionRankingInformation,
-            lastYearSameWeekVisitorStatisticsInformation = lastYearSameWeekVisitorStatisticsInformation,
             sigunguMainEventInformation = sigunguMainEventInformation,
             ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation = ongoingOrUpComingSigunguEventsFromTodayToMonthEndInformation,
         )
@@ -57,5 +53,22 @@ class DashboardFacade(
         )
 
         return shortTermForecastInformation
+    }
+
+    @CountMongoDbCommands
+    fun findVisitorStatistics(
+        userId: String,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): VisitorStatisticsInformation {
+        val foundUserBusinessDto = userService.findBusiness(userId)
+
+        val visitorStatisticInformation = touristAttractionService.findVisitorStatistics(
+            sigunguCode = foundUserBusinessDto.sigunguCode,
+            startDate = startDate,
+            endDate = endDate,
+        )
+
+        return visitorStatisticInformation
     }
 }

--- a/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/service/DashboardFacade.kt
@@ -3,7 +3,7 @@ package thatline.localup.dashboard.service
 import org.springframework.stereotype.Service
 import thatline.localup.common.annotation.CountMongoDbCommands
 import thatline.localup.dashboard.dto.DashboardOverview
-import thatline.localup.etcapi.service.WeatherService
+import thatline.localup.etcapi.service.ForecastService
 import thatline.localup.tourapi.service.TouristAttractionService
 import thatline.localup.user.service.UserService
 
@@ -11,7 +11,7 @@ import thatline.localup.user.service.UserService
 class DashboardFacade(
     private val userService: UserService,
     private val touristAttractionService: TouristAttractionService,
-    private val weatherService: WeatherService,
+    private val forecastService: ForecastService,
 ) {
     @CountMongoDbCommands
     fun getDashboardOverview(userId: String): DashboardOverview {
@@ -39,7 +39,7 @@ class DashboardFacade(
                 sigunguCode = foundUserBusinessDto.sigunguCode,
             )
 
-        val weatherInformation = weatherService.findShortTermForecast(
+        val weatherInformation = forecastService.findShortTermForecast(
             sigunguCode = foundUserBusinessDto.sigunguCode
         )
 

--- a/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecast.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecast.kt
@@ -3,12 +3,12 @@ package thatline.localup.etcapi.dto
 import java.time.LocalTime
 
 data class HourlyShortTermForecast(
-    val time: LocalTime,                                                        // 예보 시각 (fcstTime, HHmm) V
+    val time: LocalTime,                                                        // 예보 시각 (fcstTime, HHmm)
     val precipitationProbability: Int?,                                         // POP (강수확률, %)
     val precipitationType: HourlyShortTermForecastPrecipitationType?,           // PTY (강수형태)
-    val precipitationAmount: HourlyShortTermForecastPrecipitationAmountType?,   // PCP (1시간 강수량, mm) 1 강수없음 파싱 실패 시 V
+    val precipitationAmount: HourlyShortTermForecastPrecipitationAmountType?,   // PCP (1시간 강수량, mm)
     val humidity: Int?,                                                         // REH (습도, %)
-    val snowfallAmount: HourlyShortTermForecastSnowfallAmountType?,             // SNO (1시간 신적설, cm) 숫자 파싱 실패 시 V
+    val snowfallAmount: HourlyShortTermForecastSnowfallAmountType?,             // SNO (1시간 신적설, cm)
     val skyCondition: HourlyShortTermForecastSkyConditionType?,                 // SKY (하늘상태)
     val temperature: Double?,                                                   // TMP (1시간 기온, ℃)
     val windUComponent: Double?,                                                // UUU (풍속 동서성분, m/s)

--- a/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecast.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecast.kt
@@ -1,0 +1,20 @@
+package thatline.localup.etcapi.dto
+
+import java.time.LocalTime
+
+data class HourlyShortTermForecast(
+    val time: LocalTime,                                                        // 예보 시각 (fcstTime, HHmm) V
+    val precipitationProbability: Int?,                                         // POP (강수확률, %)
+    val precipitationType: HourlyShortTermForecastPrecipitationType?,           // PTY (강수형태)
+    val precipitationAmount: HourlyShortTermForecastPrecipitationAmountType?,   // PCP (1시간 강수량, mm) 1 강수없음 파싱 실패 시 V
+    val humidity: Int?,                                                         // REH (습도, %)
+    val snowfallAmount: HourlyShortTermForecastSnowfallAmountType?,             // SNO (1시간 신적설, cm) 숫자 파싱 실패 시 V
+    val skyCondition: HourlyShortTermForecastSkyConditionType?,                 // SKY (하늘상태)
+    val temperature: Double?,                                                   // TMP (1시간 기온, ℃)
+    val windUComponent: Double?,                                                // UUU (풍속 동서성분, m/s)
+    val windVComponent: Double?,                                                // VVV (풍속 남북성분, m/s)
+    val waveHeight: Int?,                                                       // WAV (파고, M)
+    val windDirection: Int?,                                                    // VEC (풍향, deg)
+    val windSpeed: Double?,                                                     // WSD (풍속, m/s)
+    val windSpeedType: HourlyShortTermForecastWindSpeedType?,                   // 추가, 풍속 타입
+)

--- a/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecastPrecipitationAmountType.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecastPrecipitationAmountType.kt
@@ -1,0 +1,40 @@
+package thatline.localup.etcapi.dto
+
+enum class HourlyShortTermForecastPrecipitationAmountType(
+    val code: Int,
+    val label: String,
+    val criteria: String,
+) {
+    NONE(
+        code = 0,
+        label = "없음",
+        criteria = "강수 없음"
+    ),
+    LIGHT(
+        code = 1,
+        label = "약한 비",
+        criteria = "시간당 3mm 미만"
+    ),
+    MODERATE(
+        code = 2,
+        label = "보통 비",
+        criteria = "시간당 3mm 이상 15mm 미만"
+    ),
+    HEAVY(
+        code = 3,
+        label = "강한 비",
+        criteria = "시간당 15mm 이상"
+    );
+
+    companion object {
+        fun fromCodeOrNull(code: String?): HourlyShortTermForecastPrecipitationAmountType? =
+            when (code?.trim()) {
+                "강수없음" -> NONE
+                "0" -> NONE
+                "1" -> LIGHT
+                "2" -> MODERATE
+                "3" -> HEAVY
+                else -> null
+            }
+    }
+}

--- a/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecastPrecipitationType.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecastPrecipitationType.kt
@@ -1,0 +1,35 @@
+package thatline.localup.etcapi.dto
+
+// NOTE-noah: 초단기와 다름
+enum class HourlyShortTermForecastPrecipitationType(
+    val code: Int,
+    val label: String,
+) {
+    NONE(
+        code = 0,
+        label = "없음"
+    ),
+    RAIN(
+        code = 1,
+        label = "비"
+    ),
+    RAIN_AND_SNOW(
+        code = 2,
+        label = "비/눈"
+    ),
+    SHOWER(
+        code = 3,
+        label = "소나기"
+    );
+
+    companion object {
+        fun fromCodeOrNull(code: String?): HourlyShortTermForecastPrecipitationType? =
+            when (code?.trim()?.toIntOrNull()) {
+                0 -> NONE
+                1 -> RAIN
+                2 -> RAIN_AND_SNOW
+                3 -> SHOWER
+                else -> null
+            }
+    }
+}

--- a/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecastSkyConditionType.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecastSkyConditionType.kt
@@ -1,0 +1,29 @@
+package thatline.localup.etcapi.dto
+
+enum class HourlyShortTermForecastSkyConditionType(
+    val code: Int,
+    val label: String,
+) {
+    SUNNY(
+        code = 1,
+        label = "맑음"
+    ),
+    PARTLY_CLOUDY(
+        code = 3,
+        label = "구름 많음"
+    ),
+    CLOUDY(
+        code = 4,
+        label = "흐림"
+    );
+
+    companion object {
+        fun fromCodeOrNull(code: String?): HourlyShortTermForecastSkyConditionType? =
+            when (code?.trim()?.toIntOrNull()) {
+                1 -> SUNNY
+                3 -> PARTLY_CLOUDY
+                4 -> CLOUDY
+                else -> null
+            }
+    }
+}

--- a/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecastSnowfallAmountType.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecastSnowfallAmountType.kt
@@ -1,0 +1,33 @@
+package thatline.localup.etcapi.dto
+
+enum class HourlyShortTermForecastSnowfallAmountType(
+    val code: Int,
+    val label: String,
+    val criteria: String,
+) {
+    NONE(
+        code = 0,
+        label = "없음",
+        criteria = "적설 없음"
+    ),
+    NORMAL(
+        code = 1,
+        label = "보통 눈",
+        criteria = "시간당 1cm 미만"
+    ),
+    HEAVY(
+        code = 2,
+        label = "많은 눈",
+        criteria = "시간당 1cm 이상"
+    );
+
+    companion object {
+        fun fromCodeOrNull(code: String?): HourlyShortTermForecastSnowfallAmountType? =
+            when (code?.trim()) {
+                "적설없음" -> NONE
+                "0" -> NORMAL
+                "1" -> HEAVY
+                else -> null
+            }
+    }
+}

--- a/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecastWindSpeedType.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/dto/HourlyShortTermForecastWindSpeedType.kt
@@ -1,0 +1,31 @@
+package thatline.localup.etcapi.dto
+
+enum class HourlyShortTermForecastWindSpeedType(
+    val code: Int,
+    val label: String,
+    val criteria: String,
+) {
+    WEAK(
+        code = 1,
+        label = "약한 바람",
+        criteria = "4m/s 미만"
+    ),
+    MODERATE(
+        code = 2,
+        label = "약간 강한 바람",
+        criteria = "4m/s 이상 9m/s 미만"
+    ),
+    STRONG(
+        code = 3,
+        label = "강한 바람",
+        criteria = "9m/s 이상"
+    );
+
+    companion object {
+        fun fromValue(speed: Double): HourlyShortTermForecastWindSpeedType = when {
+            speed < 4.0 -> WEAK
+            speed < 9.0 -> MODERATE
+            else -> STRONG
+        }
+    }
+}

--- a/src/main/kotlin/thatline/localup/etcapi/dto/ShortTermForecast.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/dto/ShortTermForecast.kt
@@ -1,0 +1,12 @@
+package thatline.localup.etcapi.dto
+
+import java.time.LocalDate
+
+data class ShortTermForecast(
+    val date: LocalDate,
+
+    val dailyMinimumTemperature: Double?, // TMN (일 최저기온, ℃)
+    val dailyMaximumTemperature: Double?, // TMX (일 최고기온, ℃)
+
+    val hourlyShortTermForecasts: List<HourlyShortTermForecast>,
+)

--- a/src/main/kotlin/thatline/localup/etcapi/dto/ShortTermForecastInformation.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/dto/ShortTermForecastInformation.kt
@@ -1,0 +1,8 @@
+package thatline.localup.etcapi.dto
+
+import java.time.LocalDateTime
+
+data class ShortTermForecastInformation(
+    val updatedDate: LocalDateTime,
+    val shortTermForecasts: List<ShortTermForecast>,
+)

--- a/src/main/kotlin/thatline/localup/etcapi/exception/KmaApiException.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/exception/KmaApiException.kt
@@ -1,0 +1,10 @@
+package thatline.localup.etcapi.exception
+
+import thatline.localup.common.exception.BaseException
+
+// KMA(Korea Meteorological Administration, 기상청) 예외
+open class KmaApiException(
+    message: String = "KMA_API",
+    cause: Throwable? = null,
+    val failedUri: String,
+) : BaseException(message, cause)

--- a/src/main/kotlin/thatline/localup/etcapi/exception/handler/EtcApiExceptionHandler.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/exception/handler/EtcApiExceptionHandler.kt
@@ -1,0 +1,29 @@
+package thatline.localup.etcapi.exception.handler
+
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import thatline.localup.common.response.BaseResponse
+import thatline.localup.etcapi.exception.KmaApiException
+
+@RestControllerAdvice
+class EtcApiExceptionHandler {
+    companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java)
+    }
+
+    @ExceptionHandler(KmaApiException::class)
+    fun handleKmaApiException(exception: KmaApiException): ResponseEntity<BaseResponse<Unit>> {
+        logger.error(
+            "KMA API failed. URI: {}, message: {}",
+            exception.failedUri,
+            exception.message,
+        )
+
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(BaseResponse.failure())
+    }
+}

--- a/src/main/kotlin/thatline/localup/etcapi/response/GetUltraSrtNcstResponse.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/response/GetUltraSrtNcstResponse.kt
@@ -70,6 +70,8 @@ data class GetUltraSrtNcstResponse(
     data class Item(
         val baseDate: String,
         val baseTime: String,
+        // T1H(기온), RN1(1시간 강수량), SKY(하늘상태, option), UUU(동서바람성분), VVV(남북바람성분),
+        // REH(습도), PTY(강수형태), LGT(낙뢰, option), VEC(풍향), WSD(풍속)
         val category: String,
         val nx: Int,
         val ny: Int,

--- a/src/main/kotlin/thatline/localup/etcapi/response/GetVilageFcstResponse.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/response/GetVilageFcstResponse.kt
@@ -72,6 +72,8 @@ data class GetVilageFcstResponse(
     data class Item(
         val baseDate: String,
         val baseTime: String,
+        // POP(강수확률), PTY(강수형태), PCP(1시간 강수량), REH(습도), SNO(1시간 신적설), SKY(하늘상태), TMP(1시간 기온),
+        // TMN(일 최저기온), TMX(일 최고기온), UUU(풍속(동서성분)), VVV(풍속(남북성분)), WAV(파고), VEC(풍향), WSD(풍속)
         val category: String,
         val fcstDate: String,
         val fcstTime: String,

--- a/src/main/kotlin/thatline/localup/etcapi/restclient/EtcApiRestClient.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/restclient/EtcApiRestClient.kt
@@ -9,6 +9,7 @@ import thatline.localup.common.annotation.ApiWindow
 import thatline.localup.common.annotation.OpenApiQuota
 import thatline.localup.common.property.EtcApiProperty
 import thatline.localup.etcapi.exception.ExternalEtcApiException
+import thatline.localup.etcapi.exception.KmaApiException
 import thatline.localup.etcapi.response.GetFcstVersionResponse
 import thatline.localup.etcapi.response.GetUltraSrtNcstResponse
 import thatline.localup.etcapi.response.GetVilageFcstResponse
@@ -65,13 +66,14 @@ class EtcApiRestClient(
             .build(true)
             .toUri()
 
-        val response = retrieveTourApi(uri, GetUltraSrtNcstResponse::class.java)
+        val response = retrieveEtcApi(uri, GetUltraSrtNcstResponse::class.java)
 
-        if (response.response.header.resultCode != "00") {
-            logger.warn(
-                "resultCode={}, resultMsg={}",
-                response.response.header.resultCode,
-                response.response.header.resultMsg
+        val responseHeader = response.response.header
+
+        if (responseHeader.resultCode != "0000") {
+            throw KmaApiException(
+                failedUri = uri.toString(),
+                message = "responseCode: ${responseHeader.resultCode}, responseMessage: ${responseHeader.resultMsg}",
             )
         }
 
@@ -117,13 +119,14 @@ class EtcApiRestClient(
             .build(true)
             .toUri()
 
-        val response = retrieveTourApi(uri, GetVilageFcstResponse::class.java)
+        val response = retrieveEtcApi(uri, GetVilageFcstResponse::class.java)
 
-        if (response.response.header.resultCode != "00") {
-            logger.warn(
-                "resultCode={}, resultMsg={}",
-                response.response.header.resultCode,
-                response.response.header.resultMsg
+        val responseHeader = response.response.header
+
+        if (responseHeader.resultCode != "0000") {
+            throw KmaApiException(
+                failedUri = uri.toString(),
+                message = "responseCode: ${responseHeader.resultCode}, responseMessage: ${responseHeader.resultMsg}",
             )
         }
 
@@ -163,20 +166,21 @@ class EtcApiRestClient(
             .build(true)
             .toUri()
 
-        val response = retrieveTourApi(uri, GetFcstVersionResponse::class.java)
+        val response = retrieveEtcApi(uri, GetFcstVersionResponse::class.java)
 
-        if (response.response.header.resultCode != "00") {
-            logger.warn(
-                "resultCode={}, resultMsg={}",
-                response.response.header.resultCode,
-                response.response.header.resultMsg
+        val responseHeader = response.response.header
+
+        if (responseHeader.resultCode != "0000") {
+            throw KmaApiException(
+                failedUri = uri.toString(),
+                message = "responseCode: ${responseHeader.resultCode}, responseMessage: ${responseHeader.resultMsg}",
             )
         }
 
         return response
     }
 
-    private fun <T> retrieveTourApi(
+    private fun <T> retrieveEtcApi(
         uri: URI,
         responseType: Class<T>,
     ): T {

--- a/src/main/kotlin/thatline/localup/etcapi/restclient/EtcApiRestClient.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/restclient/EtcApiRestClient.kt
@@ -12,8 +12,6 @@ import thatline.localup.etcapi.exception.ExternalEtcApiException
 import thatline.localup.etcapi.response.GetFcstVersionResponse
 import thatline.localup.etcapi.response.GetUltraSrtNcstResponse
 import thatline.localup.etcapi.response.GetVilageFcstResponse
-import thatline.localup.tourapi.restclient.TourApiRestClient
-import thatline.localup.tourapi.restclient.TourApiRestClient.Companion
 import java.net.URI
 
 // TODO: RENAME

--- a/src/main/kotlin/thatline/localup/etcapi/restclient/EtcApiRestClient.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/restclient/EtcApiRestClient.kt
@@ -12,6 +12,8 @@ import thatline.localup.etcapi.exception.ExternalEtcApiException
 import thatline.localup.etcapi.response.GetFcstVersionResponse
 import thatline.localup.etcapi.response.GetUltraSrtNcstResponse
 import thatline.localup.etcapi.response.GetVilageFcstResponse
+import thatline.localup.tourapi.restclient.TourApiRestClient
+import thatline.localup.tourapi.restclient.TourApiRestClient.Companion
 import java.net.URI
 
 // TODO: RENAME
@@ -22,15 +24,17 @@ class EtcApiRestClient(
     private val etcApiProperty: EtcApiProperty,
     private val restClient: RestClient,
 ) {
-    private val log = LoggerFactory.getLogger(this::class.java)
+    companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java)
+    }
 
     /**
      * 기상청_단기예보 ((구) 동네예보) 조회서비스: 초단기실황조회
      *
      * @param pageNo 페이지 번호
-     * @param numOfRows 한 페이지에 포함할 결과 수
-     * @param baseDate 발표 일자
-     * @param baseTime 발표 시각
+     * @param numOfRows 한 페이지에 포함할 결과 수 (10건씩 묶어서 사용하면 좋음)
+     * @param baseDate 발표 일자 (최근 1일 간의 자료만 제공)
+     * @param baseTime 발표 시각 (정시 생성, 10분마다 업데이트)
      * @param nx 예보 지점의 X 좌표
      * @param ny 예보 지점의 Y 좌표
      * @return [GetUltraSrtNcstResponse]
@@ -66,7 +70,7 @@ class EtcApiRestClient(
         val response = retrieveTourApi(uri, GetUltraSrtNcstResponse::class.java)
 
         if (response.response.header.resultCode != "00") {
-            log.warn(
+            logger.warn(
                 "resultCode={}, resultMsg={}",
                 response.response.header.resultCode,
                 response.response.header.resultMsg
@@ -81,8 +85,8 @@ class EtcApiRestClient(
      *
      * @param pageNo 페이지 번호
      * @param numOfRows 한 페이지에 포함할 결과 수
-     * @param baseDate 발표 일자
-     * @param baseTime 발표 시각
+     * @param baseDate 발표 일자 (최근 1일 간의 자료만 제공)
+     * @param baseTime 발표 시각 (0200, 0500, 0800, 1100, 1400, 1700, 2000, 2300)
      * @param nx 예보 지점의 X 좌표
      * @param ny 예보 지점의 Y 좌표
      * @return [GetVilageFcstResponse]
@@ -118,7 +122,7 @@ class EtcApiRestClient(
         val response = retrieveTourApi(uri, GetVilageFcstResponse::class.java)
 
         if (response.response.header.resultCode != "00") {
-            log.warn(
+            logger.warn(
                 "resultCode={}, resultMsg={}",
                 response.response.header.resultCode,
                 response.response.header.resultMsg
@@ -164,7 +168,7 @@ class EtcApiRestClient(
         val response = retrieveTourApi(uri, GetFcstVersionResponse::class.java)
 
         if (response.response.header.resultCode != "00") {
-            log.warn(
+            logger.warn(
                 "resultCode={}, resultMsg={}",
                 response.response.header.resultCode,
                 response.response.header.resultMsg
@@ -178,6 +182,8 @@ class EtcApiRestClient(
         uri: URI,
         responseType: Class<T>,
     ): T {
+        logger.debug("URI: {}", uri.toString())
+
         try {
             return restClient.get()
                 .uri(uri)

--- a/src/main/kotlin/thatline/localup/etcapi/restclient/EtcApiRestClient.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/restclient/EtcApiRestClient.kt
@@ -70,7 +70,7 @@ class EtcApiRestClient(
 
         val responseHeader = response.response.header
 
-        if (responseHeader.resultCode != "0000") {
+        if (responseHeader.resultCode != "00") {
             throw KmaApiException(
                 failedUri = uri.toString(),
                 message = "responseCode: ${responseHeader.resultCode}, responseMessage: ${responseHeader.resultMsg}",
@@ -123,7 +123,7 @@ class EtcApiRestClient(
 
         val responseHeader = response.response.header
 
-        if (responseHeader.resultCode != "0000") {
+        if (responseHeader.resultCode != "00") {
             throw KmaApiException(
                 failedUri = uri.toString(),
                 message = "responseCode: ${responseHeader.resultCode}, responseMessage: ${responseHeader.resultMsg}",
@@ -170,7 +170,7 @@ class EtcApiRestClient(
 
         val responseHeader = response.response.header
 
-        if (responseHeader.resultCode != "0000") {
+        if (responseHeader.resultCode != "00") {
             throw KmaApiException(
                 failedUri = uri.toString(),
                 message = "responseCode: ${responseHeader.resultCode}, responseMessage: ${responseHeader.resultMsg}",

--- a/src/main/kotlin/thatline/localup/etcapi/service/ForecastService.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/service/ForecastService.kt
@@ -17,9 +17,11 @@ class ForecastService(
 ) {
     fun findShortTermForecast(
         sigunguCode: String,
-        baseDate: String = LocalDateTime.now().format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd),
-        baseTime: String = "0200",
+        dateTime: LocalDateTime = LocalDateTime.now(),
     ): List<ShortTermForecast> {
+        val baseDate = dateTime.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
+        val baseTime = "0200"
+
         // TODO: 로직 개선 필요
         val tourApiLocation = TourApi.getTourApiAreaBySigunguCode(sigunguCode)
             ?: throw IllegalArgumentException()

--- a/src/main/kotlin/thatline/localup/etcapi/service/ForecastService.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/service/ForecastService.kt
@@ -1,6 +1,9 @@
 package thatline.localup.etcapi.service
 
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
+import thatline.localup.common.constant.CacheKeyGeneratorName
+import thatline.localup.common.constant.CacheObjectName
 import thatline.localup.common.constant.TourApi
 import thatline.localup.common.util.DateTimeUtil
 import thatline.localup.etcapi.dto.*
@@ -15,10 +18,15 @@ import java.time.format.DateTimeFormatter
 class ForecastService(
     private val etcApiRestClient: EtcApiRestClient,
 ) {
+    @Cacheable(
+        cacheNames = [CacheObjectName.SHORT_TERM_FORECAST_INFORMATION],
+        keyGenerator = CacheKeyGeneratorName.SHORT_TERM_FORECAST_INFORMATION,
+        sync = true
+    )
     fun findShortTermForecast(
         sigunguCode: String,
         dateTime: LocalDateTime = LocalDateTime.now(),
-    ): List<ShortTermForecast> {
+    ): ShortTermForecastInformation {
         val baseDate = dateTime.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
         val baseTime = "0200"
 
@@ -40,7 +48,10 @@ class ForecastService(
         // RestClient 단에서 검사하기 때문에 !! 사용
         val shortTermForecasts = convertToShortTermForecasts(response.response.body!!.items.item).take(3)
 
-        return shortTermForecasts
+        return ShortTermForecastInformation(
+            updatedDate = dateTime,
+            shortTermForecasts = shortTermForecasts,
+        )
     }
 
     fun convertToShortTermForecasts(items: List<GetVilageFcstResponse.Item>): List<ShortTermForecast> {

--- a/src/main/kotlin/thatline/localup/etcapi/service/ForecastService.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/service/ForecastService.kt
@@ -12,7 +12,7 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 @Service
-class WeatherService(
+class ForecastService(
     private val etcApiRestClient: EtcApiRestClient,
 ) {
     fun findShortTermForecast(

--- a/src/main/kotlin/thatline/localup/etcapi/service/WeatherService.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/service/WeatherService.kt
@@ -10,10 +10,13 @@ import thatline.localup.common.util.DateTimeUtil
 import thatline.localup.etcapi.dto.DailyWeather
 import thatline.localup.etcapi.dto.WeatherCondition
 import thatline.localup.etcapi.dto.WeatherInformation
+import thatline.localup.etcapi.response.GetVilageFcstResponse
 import thatline.localup.etcapi.restclient.EtcApiRestClient
 import thatline.localup.localup.exception.WeatherServiceException
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
 @Service
@@ -22,69 +25,97 @@ class WeatherService(
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
 
-    @Cacheable(
-        cacheNames = [CacheObjectName.WEATHER_INFORMATION],
-        keyGenerator = CacheKeyGeneratorName.WEATHER_INFORMATION,
-        sync = true
-    )
-    fun getThreeDayWeatherSummaries(
-        sigunguCode: String,
-    ): WeatherInformation {
-        val baseDateTime = LocalDateTime.now()
-            .minusMinutes(10) // 단기예보조회, API 제공 시간 10분 보정
-            .truncatedTo(ChronoUnit.HOURS)
-        val baseDate = baseDateTime.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
-        val baseTime = "0200"
 
+//    @Deprecated("대체")
+//    @Cacheable(
+//        cacheNames = [CacheObjectName.WEATHER_INFORMATION],
+//        keyGenerator = CacheKeyGeneratorName.WEATHER_INFORMATION,
+//        sync = true
+//    )
+//    fun getThreeDayWeatherSummaries(
+//        sigunguCode: String,
+//    ): WeatherInformation {
+//        val baseDateTime = LocalDateTime.now()
+//            .minusMinutes(10) // 단기예보조회, API 제공 시간 10분 보정
+//            .truncatedTo(ChronoUnit.HOURS)
+//        val baseDate = baseDateTime.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
+//        val baseTime = "0200"
+//
+//        // TODO: 로직 개선 필요
+//        val tourApiArea = TourApi.getTourApiAreaBySigunguCode(sigunguCode)
+//            ?: throw IllegalArgumentException()
+//
+//        val response = etcApiRestClient.getVilageFcst(
+//            pageNo = 1,
+//            numOfRows = 834, // 기준 날짜(254개) + 내일(290개) + 모레(290개)
+//            baseDate = baseDate,
+//            baseTime = baseTime,
+//            nx = tourApiArea.nx,
+//            ny = tourApiArea.ny,
+//        )
+//
+//        val body = response.response.body
+//            ?: throw WeatherServiceException(message = "BODY_IS_NULL")
+//
+//        val dailyWeatherList = body.items.item
+//            .groupBy { it.fcstDate }
+//            .toSortedMap().entries.map { (date, items) ->
+//                val precipitationTypeValues = items
+//                    .filter { it.category == "PTY" }
+//                    .map { it.fcstValue }
+//
+//                val skyConditionValues = items
+//                    .filter { it.category == "SKY" }
+//                    .map { it.fcstValue }
+//
+//                val condition =
+//                    if (precipitationTypeValues.any { it != "0" }) {
+//                        determinePrecipitationCondition(precipitationTypeValues)
+//                    } else {
+//                        determineSkyCondition(skyConditionValues)
+//                    }
+//
+//                val minimumTemperature = items.first { it.category == "TMN" }.fcstValue.toDouble()
+//                val maximumTemperature = items.first { it.category == "TMX" }.fcstValue.toDouble()
+//
+//                DailyWeather(
+//                    date = LocalDate.parse(date, DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd),
+//                    condition = condition,
+//                    minimumTemperature = minimumTemperature,
+//                    maximumTemperature = maximumTemperature,
+//                )
+//            }
+//
+//        return WeatherInformation(
+//            updatedDate = getThreeHourBaseDateTime(),
+//            dailyWeatherList = dailyWeatherList,
+//        )
+//    }
+
+    fun findShortTermForecast(
+        sigunguCode: String,
+        baseDate: String = LocalDateTime.now().format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd),
+        baseTime: String = "0200",
+    ): List<ShortTermForecast> {
         // TODO: 로직 개선 필요
-        val tourApiArea = TourApi.getTourApiAreaBySigunguCode(sigunguCode)
+        val tourApiLocation = TourApi.getTourApiAreaBySigunguCode(sigunguCode)
             ?: throw IllegalArgumentException()
 
+        // numOfRows: 기준 날짜(254개) + 내일(290개) + 모레(290개)
+        // 1000개 사용 시 오늘, 내일, 모레 값 받을 수 있음
         val response = etcApiRestClient.getVilageFcst(
             pageNo = 1,
-            numOfRows = 834, // 기준 날짜(254개) + 내일(290개) + 모레(290개)
+            numOfRows = 1000,
             baseDate = baseDate,
             baseTime = baseTime,
-            nx = tourApiArea.nx,
-            ny = tourApiArea.ny,
+            nx = tourApiLocation.nx,
+            ny = tourApiLocation.ny,
         )
 
-        val body = response.response.body
-            ?: throw WeatherServiceException(message = "BODY_IS_NULL")
+        // RestClient 단에서 검사하기 때문에 !! 사용
+        val shortTermForecasts = convertToShortTermForecasts(response.response.body!!.items.item).take(3)
 
-        val dailyWeatherList = body.items.item
-            .groupBy { it.fcstDate }
-            .toSortedMap().entries.map { (date, items) ->
-                val precipitationTypeValues = items
-                    .filter { it.category == "PTY" }
-                    .map { it.fcstValue }
-
-                val skyConditionValues = items
-                    .filter { it.category == "SKY" }
-                    .map { it.fcstValue }
-
-                val condition =
-                    if (precipitationTypeValues.any { it != "0" }) {
-                        determinePrecipitationCondition(precipitationTypeValues)
-                    } else {
-                        determineSkyCondition(skyConditionValues)
-                    }
-
-                val minimumTemperature = items.first { it.category == "TMN" }.fcstValue.toDouble()
-                val maximumTemperature = items.first { it.category == "TMX" }.fcstValue.toDouble()
-
-                DailyWeather(
-                    date = LocalDate.parse(date, DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd),
-                    condition = condition,
-                    minimumTemperature = minimumTemperature,
-                    maximumTemperature = maximumTemperature,
-                )
-            }
-
-        return WeatherInformation(
-            updatedDate = getThreeHourBaseDateTime(),
-            dailyWeatherList = dailyWeatherList,
-        )
+        return shortTermForecasts
     }
 
     private fun determinePrecipitationCondition(precipitationTypeValues: List<String>): WeatherCondition {
@@ -137,5 +168,262 @@ class WeatherService(
 
         return now.truncatedTo(ChronoUnit.HOURS)
             .withHour((now.hour / 3) * 3)
+    }
+
+    fun convertToShortTermForecasts(items: List<GetVilageFcstResponse.Item>): List<ShortTermForecast> {
+        // 날짜별로 그룹핑
+        return items.groupBy { it.fcstDate }
+            .map { (fcstDate, group) ->
+                toShortTermForecast(fcstDate, group)
+            }
+            .sortedBy { it.date }
+    }
+
+    private fun toShortTermForecast(forecastDate: String, items: List<GetVilageFcstResponse.Item>): ShortTermForecast {
+        val date = LocalDate.parse(forecastDate, DateTimeFormatter.BASIC_ISO_DATE)
+
+        val byCategory = items.groupBy { it.category }
+        val dailyMinimumTemperature: Double? = byCategory["TMN"]
+            ?.mapNotNull { it.fcstValue.toDoubleOrNull() }
+            ?.minOrNull()
+        val dailyMaximumTemperature: Double? = byCategory["TMX"]
+            ?.mapNotNull { it.fcstValue.toDoubleOrNull() }
+            ?.maxOrNull()
+
+        // 예보 시간별로 그룹핑
+        val hourlyForecasts = items.groupBy { it.fcstTime }
+            .map { (time, group) ->
+                val map = group.associateBy { it.category }
+
+                val pcp = map["PCP"]?.fcstValue
+                val wsd = map["WSD"]?.fcstValue?.toDoubleOrNull()
+
+                HourlyShortTermForecast(
+                    time = LocalTime.parse(time, DateTimeUtil.DATETIME_FORMATTER_HHmm),
+
+                    precipitationProbability = map["POP"]?.fcstValue?.toIntOrNull(),
+                    precipitationType = map["PTY"]?.fcstValue?.let {
+                        HourlyShortTermForecastPrecipitationType.fromCodeOrNull(
+                            it
+                        )
+                    },
+                    precipitationAmount = pcp?.let { HourlyShortTermForecastPrecipitationAmountType.fromCodeOrNull(it) },
+                    humidity = map["REH"]?.fcstValue?.toIntOrNull(),
+                    snowfallAmount = map["SNO"]?.fcstValue?.let {
+                        HourlyShortTermForecastSnowfallAmountType.fromCodeOrNull(
+                            it
+                        )
+                    },
+                    skyCondition = map["SKY"]?.fcstValue?.let {
+                        HourlyShortTermForecastSkyConditionType.fromCodeOrNull(
+                            it
+                        )
+                    },
+                    temperature = map["TMP"]?.fcstValue?.toDoubleOrNull(),
+                    windUComponent = map["UUU"]?.fcstValue?.toDoubleOrNull(),
+                    windVComponent = map["VVV"]?.fcstValue?.toDoubleOrNull(),
+                    waveHeight = map["WAV"]?.fcstValue?.toIntOrNull(),
+                    windDirection = map["VEC"]?.fcstValue?.toIntOrNull(),
+                    windSpeed = wsd,
+                    windSpeedType = wsd?.let { HourlyShortTermForecastWindSpeedType.fromValue(it) }
+                )
+            }
+            .sortedBy { it.time }
+
+        return ShortTermForecast(
+            date = date,
+            dailyMinimumTemperature = dailyMinimumTemperature,
+            dailyMaximumTemperature = dailyMaximumTemperature,
+            hourlyShortTermForecasts = hourlyForecasts,
+        )
+    }
+}
+
+data class ShortTermForecast(
+    val date: LocalDate,
+
+    val dailyMinimumTemperature: Double?, // TMN (일 최저기온, ℃)
+    val dailyMaximumTemperature: Double?, // TMX (일 최고기온, ℃)
+
+    val hourlyShortTermForecasts: List<HourlyShortTermForecast>,
+)
+
+data class HourlyShortTermForecast(
+    val time: LocalTime,                                                        // 예보 시각 (fcstTime, HHmm) V
+    val precipitationProbability: Int?,                                         // POP (강수확률, %)
+    val precipitationType: HourlyShortTermForecastPrecipitationType?,           // PTY (강수형태)
+    val precipitationAmount: HourlyShortTermForecastPrecipitationAmountType?,   // PCP (1시간 강수량, mm) 1 강수없음 파싱 실패 시 V
+    val humidity: Int?,                                                         // REH (습도, %)
+    val snowfallAmount: HourlyShortTermForecastSnowfallAmountType?,             // SNO (1시간 신적설, cm) 숫자 파싱 실패 시 V
+    val skyCondition: HourlyShortTermForecastSkyConditionType?,                 // SKY (하늘상태)
+    val temperature: Double?,                                                   // TMP (1시간 기온, ℃)
+    val windUComponent: Double?,                                                // UUU (풍속 동서성분, m/s)
+    val windVComponent: Double?,                                                // VVV (풍속 남북성분, m/s)
+    val waveHeight: Int?,                                                       // WAV (파고, M)
+    val windDirection: Int?,                                                    // VEC (풍향, deg)
+    val windSpeed: Double?,                                                     // WSD (풍속, m/s)
+    val windSpeedType: HourlyShortTermForecastWindSpeedType?,                   // 추가, 풍속 타입
+)
+
+// NOTE-noah: 초단기와 다름
+enum class HourlyShortTermForecastPrecipitationType(
+    val code: Int,
+    val label: String,
+) {
+    NONE(
+        code = 0,
+        label = "없음"
+    ),
+    RAIN(
+        code = 1,
+        label = "비"
+    ),
+    RAIN_AND_SNOW(
+        code = 2,
+        label = "비/눈"
+    ),
+    SHOWER(
+        code = 3,
+        label = "소나기"
+    );
+
+    companion object {
+        fun fromCodeOrNull(code: String?): HourlyShortTermForecastPrecipitationType? =
+            when (code?.trim()?.toIntOrNull()) {
+                0 -> NONE
+                1 -> RAIN
+                2 -> RAIN_AND_SNOW
+                3 -> SHOWER
+                else -> null
+            }
+    }
+}
+
+enum class HourlyShortTermForecastPrecipitationAmountType(
+    val code: Int,
+    val label: String,
+    val criteria: String,
+) {
+    NONE(
+        code = 0,
+        label = "없음",
+        criteria = "강수 없음"
+    ),
+    LIGHT(
+        code = 1,
+        label = "약한 비",
+        criteria = "시간당 3mm 미만"
+    ),
+    MODERATE(
+        code = 2,
+        label = "보통 비",
+        criteria = "시간당 3mm 이상 15mm 미만"
+    ),
+    HEAVY(
+        code = 3,
+        label = "강한 비",
+        criteria = "시간당 15mm 이상"
+    );
+
+    companion object {
+        fun fromCodeOrNull(code: String?): HourlyShortTermForecastPrecipitationAmountType? =
+            when (code?.trim()) {
+                "강수없음" -> NONE
+                "0" -> NONE
+                "1" -> LIGHT
+                "2" -> MODERATE
+                "3" -> HEAVY
+                else -> null
+            }
+    }
+}
+
+enum class HourlyShortTermForecastSnowfallAmountType(
+    val code: Int,
+    val label: String,
+    val criteria: String,
+) {
+    NONE(
+        code = 0,
+        label = "없음",
+        criteria = "적설 없음"
+    ),
+    NORMAL(
+        code = 1,
+        label = "보통 눈",
+        criteria = "시간당 1cm 미만"
+    ),
+    HEAVY(
+        code = 2,
+        label = "많은 눈",
+        criteria = "시간당 1cm 이상"
+    );
+
+    companion object {
+        fun fromCodeOrNull(code: String?): HourlyShortTermForecastSnowfallAmountType? =
+            when (code?.trim()) {
+                "적설없음" -> NONE
+                "0" -> NORMAL
+                "1" -> HEAVY
+                else -> null
+            }
+    }
+}
+
+enum class HourlyShortTermForecastSkyConditionType(
+    val code: Int,
+    val label: String,
+) {
+    SUNNY(
+        code = 1,
+        label = "맑음"
+    ),
+    PARTLY_CLOUDY(
+        code = 3,
+        label = "구름 많음"
+    ),
+    CLOUDY(
+        code = 4,
+        label = "흐림"
+    );
+
+    companion object {
+        fun fromCodeOrNull(code: String?): HourlyShortTermForecastSkyConditionType? =
+            when (code?.trim()?.toIntOrNull()) {
+                1 -> SUNNY
+                3 -> PARTLY_CLOUDY
+                4 -> CLOUDY
+                else -> null
+            }
+    }
+}
+
+enum class HourlyShortTermForecastWindSpeedType(
+    val code: Int,
+    val label: String,
+    val criteria: String,
+) {
+    WEAK(
+        code = 1,
+        label = "약한 바람",
+        criteria = "4m/s 미만"
+    ),
+    MODERATE(
+        code = 2,
+        label = "약간 강한 바람",
+        criteria = "4m/s 이상 9m/s 미만"
+    ),
+    STRONG(
+        code = 3,
+        label = "강한 바람",
+        criteria = "9m/s 이상"
+    );
+
+    companion object {
+        fun fromValue(speed: Double): HourlyShortTermForecastWindSpeedType = when {
+            speed < 4.0 -> WEAK
+            speed < 9.0 -> MODERATE
+            else -> STRONG
+        }
     }
 }

--- a/src/main/kotlin/thatline/localup/etcapi/service/WeatherService.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/service/WeatherService.kt
@@ -7,7 +7,6 @@ import thatline.localup.common.constant.CacheKeyGeneratorName
 import thatline.localup.common.constant.CacheObjectName
 import thatline.localup.common.constant.TourApi
 import thatline.localup.common.util.DateTimeUtil
-import thatline.localup.etcapi.code.UltraSrtNcstResponseCode
 import thatline.localup.etcapi.dto.DailyWeather
 import thatline.localup.etcapi.dto.WeatherCondition
 import thatline.localup.etcapi.dto.WeatherInformation
@@ -49,19 +48,6 @@ class WeatherService(
             nx = tourApiArea.nx,
             ny = tourApiArea.ny,
         )
-
-        if (response.response.header.resultCode != "00") {
-            log.warn(
-                "resultCode={}, resultMsg={}",
-                response.response.header.resultCode,
-                response.response.header.resultMsg
-            )
-
-            // TODO: 로직 재사용함, 수정 필요
-            throw WeatherServiceException(
-                message = UltraSrtNcstResponseCode.from(response.response.header.resultCode).message
-            )
-        }
 
         val body = response.response.body
             ?: throw WeatherServiceException(message = "BODY_IS_NULL")

--- a/src/main/kotlin/thatline/localup/etcapi/service/WeatherService.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/service/WeatherService.kt
@@ -1,6 +1,5 @@
 package thatline.localup.etcapi.service
 
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import thatline.localup.common.constant.TourApi
 import thatline.localup.common.util.DateTimeUtil
@@ -16,8 +15,6 @@ import java.time.format.DateTimeFormatter
 class WeatherService(
     private val etcApiRestClient: EtcApiRestClient,
 ) {
-    private val log = LoggerFactory.getLogger(this::class.java)
-
     fun findShortTermForecast(
         sigunguCode: String,
         baseDate: String = LocalDateTime.now().format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd),

--- a/src/main/kotlin/thatline/localup/etcapi/service/WeatherService.kt
+++ b/src/main/kotlin/thatline/localup/etcapi/service/WeatherService.kt
@@ -1,96 +1,22 @@
 package thatline.localup.etcapi.service
 
 import org.slf4j.LoggerFactory
-import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
-import thatline.localup.common.constant.CacheKeyGeneratorName
-import thatline.localup.common.constant.CacheObjectName
 import thatline.localup.common.constant.TourApi
 import thatline.localup.common.util.DateTimeUtil
-import thatline.localup.etcapi.dto.DailyWeather
-import thatline.localup.etcapi.dto.WeatherCondition
-import thatline.localup.etcapi.dto.WeatherInformation
+import thatline.localup.etcapi.dto.*
 import thatline.localup.etcapi.response.GetVilageFcstResponse
 import thatline.localup.etcapi.restclient.EtcApiRestClient
-import thatline.localup.localup.exception.WeatherServiceException
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
 
 @Service
 class WeatherService(
     private val etcApiRestClient: EtcApiRestClient,
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
-
-
-//    @Deprecated("대체")
-//    @Cacheable(
-//        cacheNames = [CacheObjectName.WEATHER_INFORMATION],
-//        keyGenerator = CacheKeyGeneratorName.WEATHER_INFORMATION,
-//        sync = true
-//    )
-//    fun getThreeDayWeatherSummaries(
-//        sigunguCode: String,
-//    ): WeatherInformation {
-//        val baseDateTime = LocalDateTime.now()
-//            .minusMinutes(10) // 단기예보조회, API 제공 시간 10분 보정
-//            .truncatedTo(ChronoUnit.HOURS)
-//        val baseDate = baseDateTime.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
-//        val baseTime = "0200"
-//
-//        // TODO: 로직 개선 필요
-//        val tourApiArea = TourApi.getTourApiAreaBySigunguCode(sigunguCode)
-//            ?: throw IllegalArgumentException()
-//
-//        val response = etcApiRestClient.getVilageFcst(
-//            pageNo = 1,
-//            numOfRows = 834, // 기준 날짜(254개) + 내일(290개) + 모레(290개)
-//            baseDate = baseDate,
-//            baseTime = baseTime,
-//            nx = tourApiArea.nx,
-//            ny = tourApiArea.ny,
-//        )
-//
-//        val body = response.response.body
-//            ?: throw WeatherServiceException(message = "BODY_IS_NULL")
-//
-//        val dailyWeatherList = body.items.item
-//            .groupBy { it.fcstDate }
-//            .toSortedMap().entries.map { (date, items) ->
-//                val precipitationTypeValues = items
-//                    .filter { it.category == "PTY" }
-//                    .map { it.fcstValue }
-//
-//                val skyConditionValues = items
-//                    .filter { it.category == "SKY" }
-//                    .map { it.fcstValue }
-//
-//                val condition =
-//                    if (precipitationTypeValues.any { it != "0" }) {
-//                        determinePrecipitationCondition(precipitationTypeValues)
-//                    } else {
-//                        determineSkyCondition(skyConditionValues)
-//                    }
-//
-//                val minimumTemperature = items.first { it.category == "TMN" }.fcstValue.toDouble()
-//                val maximumTemperature = items.first { it.category == "TMX" }.fcstValue.toDouble()
-//
-//                DailyWeather(
-//                    date = LocalDate.parse(date, DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd),
-//                    condition = condition,
-//                    minimumTemperature = minimumTemperature,
-//                    maximumTemperature = maximumTemperature,
-//                )
-//            }
-//
-//        return WeatherInformation(
-//            updatedDate = getThreeHourBaseDateTime(),
-//            dailyWeatherList = dailyWeatherList,
-//        )
-//    }
 
     fun findShortTermForecast(
         sigunguCode: String,
@@ -116,58 +42,6 @@ class WeatherService(
         val shortTermForecasts = convertToShortTermForecasts(response.response.body!!.items.item).take(3)
 
         return shortTermForecasts
-    }
-
-    private fun determinePrecipitationCondition(precipitationTypeValues: List<String>): WeatherCondition {
-        val set = precipitationTypeValues.toSet()
-
-        return when {
-            set.any { it == "3" || it == "7" } -> WeatherCondition.SNOW
-            set.any { it == "2" || it == "6" } -> WeatherCondition.RAIN_SNOW
-            set.any { it == "1" || it == "5" } -> WeatherCondition.RAIN
-            set.any { it == "4" } -> WeatherCondition.SHOWER
-            else -> WeatherCondition.UNKNOWN
-        }
-    }
-
-    private fun determineSkyCondition(skyConditionValues: List<String>): WeatherCondition {
-        if (skyConditionValues.isEmpty()) {
-            return WeatherCondition.UNKNOWN
-        }
-
-        // 코드별 빈도 집계
-        val countsByCode: Map<String, Int> =
-            skyConditionValues.groupingBy { it }.eachCount()
-
-        // 최대 빈도 계산
-        val maxFrequency: Int =
-            countsByCode.values.maxOf { it }
-
-        // 최빈값(동률 가능) 집합 추출
-        val modes: Set<String> =
-            countsByCode.filterValues { it == maxFrequency }.keys
-
-        // 대표 코드 선택(우선순위: 4>3>1, 그 외 임의 1개)
-        val resolvedCode: String = when {
-            "4" in modes -> "4"   // 흐림
-            "3" in modes -> "3"   // 구름많음
-            "1" in modes -> "1"   // 맑음
-            else -> modes.first()
-        }
-
-        return when (resolvedCode) {
-            "4" -> WeatherCondition.CLOUDY
-            "3" -> WeatherCondition.PARTLY_CLOUDY
-            "1" -> WeatherCondition.SUNNY
-            else -> WeatherCondition.UNKNOWN
-        }
-    }
-
-    private fun getThreeHourBaseDateTime(): LocalDateTime {
-        val now = LocalDateTime.now()
-
-        return now.truncatedTo(ChronoUnit.HOURS)
-            .withHour((now.hour / 3) * 3)
     }
 
     fun convertToShortTermForecasts(items: List<GetVilageFcstResponse.Item>): List<ShortTermForecast> {
@@ -236,194 +110,5 @@ class WeatherService(
             dailyMaximumTemperature = dailyMaximumTemperature,
             hourlyShortTermForecasts = hourlyForecasts,
         )
-    }
-}
-
-data class ShortTermForecast(
-    val date: LocalDate,
-
-    val dailyMinimumTemperature: Double?, // TMN (일 최저기온, ℃)
-    val dailyMaximumTemperature: Double?, // TMX (일 최고기온, ℃)
-
-    val hourlyShortTermForecasts: List<HourlyShortTermForecast>,
-)
-
-data class HourlyShortTermForecast(
-    val time: LocalTime,                                                        // 예보 시각 (fcstTime, HHmm) V
-    val precipitationProbability: Int?,                                         // POP (강수확률, %)
-    val precipitationType: HourlyShortTermForecastPrecipitationType?,           // PTY (강수형태)
-    val precipitationAmount: HourlyShortTermForecastPrecipitationAmountType?,   // PCP (1시간 강수량, mm) 1 강수없음 파싱 실패 시 V
-    val humidity: Int?,                                                         // REH (습도, %)
-    val snowfallAmount: HourlyShortTermForecastSnowfallAmountType?,             // SNO (1시간 신적설, cm) 숫자 파싱 실패 시 V
-    val skyCondition: HourlyShortTermForecastSkyConditionType?,                 // SKY (하늘상태)
-    val temperature: Double?,                                                   // TMP (1시간 기온, ℃)
-    val windUComponent: Double?,                                                // UUU (풍속 동서성분, m/s)
-    val windVComponent: Double?,                                                // VVV (풍속 남북성분, m/s)
-    val waveHeight: Int?,                                                       // WAV (파고, M)
-    val windDirection: Int?,                                                    // VEC (풍향, deg)
-    val windSpeed: Double?,                                                     // WSD (풍속, m/s)
-    val windSpeedType: HourlyShortTermForecastWindSpeedType?,                   // 추가, 풍속 타입
-)
-
-// NOTE-noah: 초단기와 다름
-enum class HourlyShortTermForecastPrecipitationType(
-    val code: Int,
-    val label: String,
-) {
-    NONE(
-        code = 0,
-        label = "없음"
-    ),
-    RAIN(
-        code = 1,
-        label = "비"
-    ),
-    RAIN_AND_SNOW(
-        code = 2,
-        label = "비/눈"
-    ),
-    SHOWER(
-        code = 3,
-        label = "소나기"
-    );
-
-    companion object {
-        fun fromCodeOrNull(code: String?): HourlyShortTermForecastPrecipitationType? =
-            when (code?.trim()?.toIntOrNull()) {
-                0 -> NONE
-                1 -> RAIN
-                2 -> RAIN_AND_SNOW
-                3 -> SHOWER
-                else -> null
-            }
-    }
-}
-
-enum class HourlyShortTermForecastPrecipitationAmountType(
-    val code: Int,
-    val label: String,
-    val criteria: String,
-) {
-    NONE(
-        code = 0,
-        label = "없음",
-        criteria = "강수 없음"
-    ),
-    LIGHT(
-        code = 1,
-        label = "약한 비",
-        criteria = "시간당 3mm 미만"
-    ),
-    MODERATE(
-        code = 2,
-        label = "보통 비",
-        criteria = "시간당 3mm 이상 15mm 미만"
-    ),
-    HEAVY(
-        code = 3,
-        label = "강한 비",
-        criteria = "시간당 15mm 이상"
-    );
-
-    companion object {
-        fun fromCodeOrNull(code: String?): HourlyShortTermForecastPrecipitationAmountType? =
-            when (code?.trim()) {
-                "강수없음" -> NONE
-                "0" -> NONE
-                "1" -> LIGHT
-                "2" -> MODERATE
-                "3" -> HEAVY
-                else -> null
-            }
-    }
-}
-
-enum class HourlyShortTermForecastSnowfallAmountType(
-    val code: Int,
-    val label: String,
-    val criteria: String,
-) {
-    NONE(
-        code = 0,
-        label = "없음",
-        criteria = "적설 없음"
-    ),
-    NORMAL(
-        code = 1,
-        label = "보통 눈",
-        criteria = "시간당 1cm 미만"
-    ),
-    HEAVY(
-        code = 2,
-        label = "많은 눈",
-        criteria = "시간당 1cm 이상"
-    );
-
-    companion object {
-        fun fromCodeOrNull(code: String?): HourlyShortTermForecastSnowfallAmountType? =
-            when (code?.trim()) {
-                "적설없음" -> NONE
-                "0" -> NORMAL
-                "1" -> HEAVY
-                else -> null
-            }
-    }
-}
-
-enum class HourlyShortTermForecastSkyConditionType(
-    val code: Int,
-    val label: String,
-) {
-    SUNNY(
-        code = 1,
-        label = "맑음"
-    ),
-    PARTLY_CLOUDY(
-        code = 3,
-        label = "구름 많음"
-    ),
-    CLOUDY(
-        code = 4,
-        label = "흐림"
-    );
-
-    companion object {
-        fun fromCodeOrNull(code: String?): HourlyShortTermForecastSkyConditionType? =
-            when (code?.trim()?.toIntOrNull()) {
-                1 -> SUNNY
-                3 -> PARTLY_CLOUDY
-                4 -> CLOUDY
-                else -> null
-            }
-    }
-}
-
-enum class HourlyShortTermForecastWindSpeedType(
-    val code: Int,
-    val label: String,
-    val criteria: String,
-) {
-    WEAK(
-        code = 1,
-        label = "약한 바람",
-        criteria = "4m/s 미만"
-    ),
-    MODERATE(
-        code = 2,
-        label = "약간 강한 바람",
-        criteria = "4m/s 이상 9m/s 미만"
-    ),
-    STRONG(
-        code = 3,
-        label = "강한 바람",
-        criteria = "9m/s 이상"
-    );
-
-    companion object {
-        fun fromValue(speed: Double): HourlyShortTermForecastWindSpeedType = when {
-            speed < 4.0 -> WEAK
-            speed < 9.0 -> MODERATE
-            else -> STRONG
-        }
     }
 }

--- a/src/main/kotlin/thatline/localup/tourapi/dto/VisitorStatisticsInformation.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/dto/VisitorStatisticsInformation.kt
@@ -2,7 +2,7 @@ package thatline.localup.tourapi.dto
 
 import java.time.LocalDateTime
 
-data class LastYearSameWeekVisitorStatisticsInformation(
+data class VisitorStatisticsInformation(
     val updatedDate: LocalDateTime,
     val visitorStatistics: List<VisitorStatistic>,
 )

--- a/src/main/kotlin/thatline/localup/tourapi/restclient/TourApiRestClient.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/restclient/TourApiRestClient.kt
@@ -510,8 +510,8 @@ class TourApiRestClient(
      */
     @OpenApiQuota(name = "dataLabService:locgoRegnVisitrDDList", limit = 1000, ApiWindow.DAILY)
     fun dataLabServiceLocgoRegnVisitrDDList(
-        pageNo: Long,
-        numOfRows: Long,
+        pageNo: Long?,
+        numOfRows: Long?,
         startYmd: String,
         endYmd: String,
     ): LocgoRegnVisitrDDListResponse {
@@ -522,8 +522,8 @@ class TourApiRestClient(
         val uri = UriComponentsBuilder
             .fromUri(fromUri)
             .queryParam("serviceKey", tourApiProperty.dataLabService.serviceKey)
-            .queryParam("pageNo", pageNo)
-            .queryParam("numOfRows", numOfRows)
+            .queryParamIfNotNull("pageNo", pageNo)
+            .queryParamIfNotNull("numOfRows", numOfRows)
             .queryParam("MobileOS", tourApiProperty.mobileOS)
             .queryParam("MobileApp", tourApiProperty.mobileApp)
             .queryParam("startYmd", startYmd)

--- a/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
+++ b/src/main/kotlin/thatline/localup/tourapi/service/TouristAttractionService.kt
@@ -59,17 +59,16 @@ class TouristAttractionService(
         )
     }
 
-    // TODO-noah: API의 한계로 별도의 배치 작업으로 개선하면 좋을 것 같음
     @Cacheable(
-        cacheNames = [CacheObjectName.LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS_INFORMATION],
-        keyGenerator = CacheKeyGeneratorName.LAST_YEAR_SAME_WEEK_VISITOR_STATISTICS,
+        cacheNames = [CacheObjectName.VISITOR_STATISTICS_INFORMATION],
+        keyGenerator = CacheKeyGeneratorName.VISITOR_STATISTICS_INFORMATION,
         sync = true
     )
-    fun findLastYearSameWeekVisitorStatistics(
+    fun findVisitorStatistics(
         sigunguCode: String,
-    ): LastYearSameWeekVisitorStatisticsInformation {
-        val (startDate, endDate) = DateTimeUtil.getLastYearSameIsoWeekRange()
-
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): VisitorStatisticsInformation {
         val startYmd = startDate.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
         val endYmd = endDate.format(DateTimeUtil.DATETIME_FORMATTER_yyyyMMdd)
 
@@ -87,13 +86,11 @@ class TouristAttractionService(
             endYmd = endYmd,
         )
 
-        val items = response2.response.body.items.item
-
-        val visitorStatistics = items
+        val visitorStatistics = response2.response.body.items.item
             .filter { it.signguCode == sigunguCode }
             .groupBy { it.baseYmd }
             .map { (date, data) ->
-                // 관광객 구분 코드
+                // 방문객 구분 코드
                 val visitorCode = data.associateBy { it.touDivCd }
 
                 VisitorStatistic(
@@ -105,7 +102,7 @@ class TouristAttractionService(
             }
             .sortedBy { it.date }
 
-        return LastYearSameWeekVisitorStatisticsInformation(
+        return VisitorStatisticsInformation(
             updatedDate = LocalDateTime.now(),
             visitorStatistics = visitorStatistics
         )

--- a/src/test/kotlin/thatline/localup/tourapi/DataLabServiceTests.kt
+++ b/src/test/kotlin/thatline/localup/tourapi/DataLabServiceTests.kt
@@ -27,12 +27,13 @@ class DataLabServiceTests {
     @Test
     @DisplayName("한국관광공사_관광빅데이터 정보서비스_GW: 기초 지자체 지역방문자수 집계 데이터 정보 조회")
     fun runDataLabServiceLocgoRegnVisitrDDList() {
-        // 지난 달, 같은 일자까지만 유효하게 처리
+        // MIN: 2018년 01월 01일
+        // MAX: 지난 달, 같은 일자까지만 유효하게 처리
         val response = restClient.dataLabServiceLocgoRegnVisitrDDList(
             pageNo = 1,
             numOfRows = 10,
-            startYmd = "20250723",
-            endYmd = "20250723"
+            startYmd = "20180101",
+            endYmd = "20180101"
         )
 
         val responseString = objectMapper

--- a/src/test/kotlin/thatline/localup/tourapi/DataLabServiceTests.kt
+++ b/src/test/kotlin/thatline/localup/tourapi/DataLabServiceTests.kt
@@ -1,0 +1,44 @@
+package thatline.localup.tourapi
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import thatline.localup.tourapi.restclient.TourApiRestClient
+
+@SpringBootTest
+@ActiveProfiles("local")
+@TestPropertySource(properties = ["logging.level.thatline.localup.tourapi.restclient.TourApiRestClient=DEBUG"])
+class DataLabServiceTests {
+    companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java)
+    }
+
+    @Autowired
+    lateinit var restClient: TourApiRestClient
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Test
+    @DisplayName("한국관광공사_관광빅데이터 정보서비스_GW: 기초 지자체 지역방문자수 집계 데이터 정보 조회")
+    fun runDataLabServiceLocgoRegnVisitrDDList() {
+        // 지난 달, 같은 일자까지만 유효하게 처리
+        val response = restClient.dataLabServiceLocgoRegnVisitrDDList(
+            pageNo = 1,
+            numOfRows = 10,
+            startYmd = "20250723",
+            endYmd = "20250723"
+        )
+
+        val responseString = objectMapper
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(response)
+
+        logger.info("\n{}", responseString)
+    }
+}

--- a/src/test/kotlin/thatline/localup/tourapi/vilageFcstInfoService_20Tests.kt
+++ b/src/test/kotlin/thatline/localup/tourapi/vilageFcstInfoService_20Tests.kt
@@ -1,0 +1,64 @@
+package thatline.localup.tourapi
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import thatline.localup.etcapi.restclient.EtcApiRestClient
+
+@SpringBootTest
+@ActiveProfiles("local")
+@TestPropertySource(properties = ["logging.level.thatline.localup.tourapi.restclient.EtcApiRestClient=DEBUG"])
+class vilageFcstInfoService_20Tests {
+    companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java)
+    }
+
+    @Autowired
+    lateinit var restClient: EtcApiRestClient
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Test
+    @DisplayName("기상청_단기예보 ((구) 동네예보) 조회서비스: 초단기실황조회")
+    fun runVilageFcstInfoService_20GetUltraSrtNcst() {
+        val response = restClient.getUltraSrtNcst(
+            pageNo = 1,
+            numOfRows = 10,
+            baseDate = "20250821",
+            baseTime = "1100",
+            nx = 55,
+            ny = 127,
+        )
+
+        val responseString = objectMapper
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(response)
+
+        logger.info("\n{}", responseString)
+    }
+
+    @Test
+    @DisplayName("기상청_단기예보 ((구) 동네예보) 조회서비스: 단기예보조회")
+    fun runVilageFcstInfoService_20GetVilageFcst() {
+        val response = restClient.getVilageFcst(
+            pageNo = 1,
+            numOfRows = 10,
+            baseDate = "20250822",
+            baseTime = "0500",
+            nx = 55,
+            ny = 127,
+        )
+
+        val responseString = objectMapper
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(response)
+
+        logger.info("\n{}", responseString)
+    }
+}


### PR DESCRIPTION
# fix: 대시보드, 방문자 수 관련 API 개선

## Note

기존에는 날짜가 고정되어 있어 활용에 제약이 있었습니다. 이를 개선하여 클라이언트에서 유동적으로 날짜를 변경해 사용할 수 있도록 기능을 확장했습니다. 객체/메서드 등 이름을 개선했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 대시보드에 단기 예보 조회 및 방문자 통계 조회(기간 지정) API 추가
  - 시간대별 예보(강수, 기온, 풍속 등)와 일최저/최고 기온 제공

- 개선
  - 방문자 통계가 사용자가 지정한 날짜 범위로 조회 가능
  - 외부 예보 API 오류 처리 강화로 실패 시 명확한 응답 및 로그 제공
  - 캐시 구성 개선으로 조회 속도 및 안정성 향상

- 보안
  - 테스트 엔드포인트 인증 예외 범위 확장: /api/dashboard/test/** 전체 허용

- 테스트
  - 외부 API 연동 관련 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->