### PR TITLE
fix: 대시보드 테스트 컨트롤러 삭제

### DIFF
--- a/src/main/kotlin/thatline/localup/dashboard/controller/DashboardController.kt
+++ b/src/main/kotlin/thatline/localup/dashboard/controller/DashboardController.kt
@@ -19,6 +19,7 @@ import thatline.localup.tourapi.dto.VisitorStatisticsInformation
 class DashboardController(
     private val dashboardFacade: DashboardFacade,
 ) {
+    // TODO-noah: 분리
     @GetMapping
     @RequireUser
     fun getDashboardOverview(
@@ -46,37 +47,6 @@ class DashboardController(
     ): ResponseEntity<BaseResponse<VisitorStatisticsInformation>> {
         val visitorStatisticsInformation = dashboardFacade.findVisitorStatistics(
             userId = userId,
-            startDate = request.startDate,
-            endDate = request.endDate,
-        )
-
-        return ResponseEntity.ok(BaseResponse.success(data = visitorStatisticsInformation))
-    }
-
-    // TODO-noah: 삭제, 아직 인증이 완료되지 않아 사용하는 코드입니다.
-    @GetMapping("/test")
-    fun getDashboardInformation(): ResponseEntity<BaseResponse<DashboardOverview>> {
-        // 해당 user id는 로컬 db에 따라 달라질 수 있습니다.
-        val dashboardOverview = dashboardFacade.getDashboardOverview("689eb417e295ca9144b875a0")
-
-        return ResponseEntity.ok(BaseResponse.success(data = dashboardOverview))
-    }
-
-    // TODO-noah: 삭제, 아직 인증이 완료되지 않아 사용하는 코드입니다.
-    @GetMapping("/test/short-term-forecast")
-    fun findShortTermForecastTest(): ResponseEntity<BaseResponse<ShortTermForecastInformation>> {
-        val shortTermForecastInformation = dashboardFacade.findShortTermForecast("689eb417e295ca9144b875a0")
-
-        return ResponseEntity.ok(BaseResponse.success(data = shortTermForecastInformation))
-    }
-
-    // TODO-noah: 삭제, 아직 인증이 완료되지 않아 사용하는 코드입니다.
-    @GetMapping("/test/visitor-statistics")
-    fun findVisitorStatisticsTest(
-        @Valid request: FindVisitorStatisticsRequest,
-    ): ResponseEntity<BaseResponse<VisitorStatisticsInformation>> {
-        val visitorStatisticsInformation = dashboardFacade.findVisitorStatistics(
-            userId = "689eb417e295ca9144b875a0",
             startDate = request.startDate,
             endDate = request.endDate,
         )


### PR DESCRIPTION
# fix: 대시보드 테스트 컨트롤러 삭제

## Note

대시보드에서 사용한 테스트 API를 삭제했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 테스트용 대시보드 API 엔드포인트 3종 제거:
    - GET /api/dashboard/test
    - GET /api/dashboard/test/short-term-forecast
    - GET /api/dashboard/test/visitor-statistics
  * 운영용 대시보드 엔드포인트는 변경 없음.
  * 내부 주석 추가(기능 영향 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->